### PR TITLE
Updating scipy requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Dependencies:
 
 DESlib is tested to work with Python 3.5, 3.6 and 3.7. The dependency requirements are:
 
-* scipy(>=0.13.3)
+* scipy(>=1.2.0)
 * numpy(>=1.10.4)
 * scikit-learn(>=0.19.0)
 

--- a/deslib/tests/test_integration_DFP_IH.py
+++ b/deslib/tests/test_integration_DFP_IH.py
@@ -57,7 +57,7 @@ def test_desp():
 
     desp = DESP(pool_classifiers, DFP=True, with_IH=True, IH_rate=0.1)
     desp.fit(X_dsel, y_dsel)
-    assert np.isclose(desp.score(X_test, y_test), 0.906060606060606)
+    assert np.isclose(desp.score(X_test, y_test), 0.9090909090909091)
 
 
 def test_ola():

--- a/deslib/tests/test_integration_dfp.py
+++ b/deslib/tests/test_integration_dfp.py
@@ -65,7 +65,7 @@ def test_kne():
 
     kne = KNORAE(pool_classifiers, DFP=True)
     kne.fit(X_dsel, y_dsel)
-    assert np.isclose(kne.score(X_test, y_test), 0.9)
+    assert np.isclose(kne.score(X_test, y_test), 0.896969696969697)
 
 
 def test_desp():
@@ -73,7 +73,7 @@ def test_desp():
 
     desp = DESP(pool_classifiers, DFP=True)
     desp.fit(X_dsel, y_dsel)
-    assert np.isclose(desp.score(X_test, y_test), 0.896969696969697)
+    assert np.isclose(desp.score(X_test, y_test), 0.8939393939393939)
 
 
 def test_ola():
@@ -143,7 +143,7 @@ def test_meta():
 
     meta_des = METADES(pool_classifiers, DFP=True)
     meta_des.fit(X_dsel, y_dsel)
-    assert np.isclose(meta_des.score(X_test, y_test), 0.9121212121212121)
+    assert np.isclose(meta_des.score(X_test, y_test), 0.9151515151515152)
 
 
 def test_knop():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy>=1.10.4
-scipy>=0.13.3
+scipy>=1.2.0
 scikit-learn>=0.19.0
 sphinx
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-scipy>=0.13.3
+scipy>=1.2.0
 numpy>=1.10.4
 scikit-learn>=0.19.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='DESlib',
       install_requires=[
           'scikit-learn>=0.19.0',
           'numpy>=1.10.4',
-          'scipy>=0.13.3',
+          'scipy>=1.2.0',
       ],
       python_requires='>=3',      
 


### PR DESCRIPTION
Updating the requirement as well as the expected values on the integration tests according to the new version of scipy.

The behavior of scipy.stats.mstats.mode when two values have the same number of elements changed on version 1.2.0. Now it returns the smallest value instead of the first value in the array  (similarly to the standard array versions).