### PR TITLE
Fix divide by zero errors

### DIFF
--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -188,6 +188,7 @@ class APosteriori(BaseDCS):
         # Guarantee that these arrays are view as a 2D array for the case where
         # a single test sample is passed down.
         predictions = np.atleast_2d(predictions)
+        distances[distances == 0] = 1e-10
 
         # Normalize the distances
         dists_normalized = 1.0 / distances

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -176,6 +176,7 @@ class APriori(BaseDCS):
             Competence level estimated for each base classifier and test
             example.
         """
+        distances[distances == 0] = 1e-10
         dists_normalized = 1.0 / distances
 
         # Get the ndarray containing the scores obtained for the correct class

--- a/deslib/des/probabilistic/base.py
+++ b/deslib/des/probabilistic/base.py
@@ -134,6 +134,11 @@ class BaseProbabilistic(BaseDES):
         """
 
         super(BaseProbabilistic, self).fit(X, y)
+
+        if self.n_classes_ == 1:
+            raise ValueError(
+                "Error. This class does not accept one class datasets!")
+
         self._check_predict_proba()
 
         self.dsel_scores_ = self._preprocess_dsel_scores()

--- a/deslib/tests/dcs/test_a_posteriori.py
+++ b/deslib/tests/dcs/test_a_posteriori.py
@@ -7,7 +7,7 @@ from deslib.dcs.a_posteriori import APosteriori
 
 
 def test_check_estimator():
-    check_estimator(APosteriori)
+    check_estimator(APosteriori(selection_method='best'))
 
 
 # Should always be 1.0 since the supports for the correct class is always 1.

--- a/deslib/util/prob_functions.py
+++ b/deslib/util/prob_functions.py
@@ -46,11 +46,20 @@ def exponential_func(n_classes, support_correct):
     C_src : array of shape = [n_samples]
         Representing the classifier competences at each data point
     """
-    support_correct[support_correct > 1.0] = 1.0
-    support_correct[support_correct < 0.0] = 0.0
-    temp = (1.0 - ((n_classes - 1.0) * support_correct) / (
-                1.0 - support_correct))
-    C_src = (1.0 - (2 ** temp))
+    support_correct[support_correct <= 0.0] = 0.0
+    C_src = np.zeros(support_correct.size)
+
+    # Special case where the support to the correct class is equal to one.
+    support_one_indices = support_correct >= 1
+    C_src[np.where(support_one_indices)[0]] = 1
+
+    # Apply the competence formula when the support is less than one
+    indices_not_one = np.where(~support_one_indices)[0]
+
+    temp = (1.0 - ((n_classes - 1.0) * support_correct[indices_not_one]) / (
+                1.0 - support_correct[indices_not_one]))
+    C_src[indices_not_one] = (1.0 - (2 ** temp))
+
     return C_src
 
 


### PR DESCRIPTION
Handling special case when a division by zero can occur:

-  the distance is equal to zero during the competence level estimation for the APriori and APosteriori classes
- When the support obtained for the correct class is exactly equal to one in the probabilistic.Exponential method.