### PR TITLE
Fixing compatibility with python 3.7.2

### DIFF
--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -422,4 +422,5 @@ def test_label_encoder_base():
     ds_test.fit(X_dsel_ex1, y_dsel_ex1)
     predictions = ds_test.predict(query)
 
-    assert np.equal(predictions, ['cat', 'dog'])
+    assert np.array_equal(predictions, np.array(['dog', 'cat']))
+


### PR DESCRIPTION
Changing the test function, `def test_label_encoder_base()` to use `np.array_equal` instead of `np.equal` to be compatible with Python 3.7.2

The function `np.equal` is giving the following error when updated to Python 3.7.2:

TypeError: ufunc 'equal' did not contain a loop with signature matching types dtype('<U5') dtype('<U5') dtype('bool')