### PR TITLE
Fix documentation link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -329,4 +329,4 @@ def linkcode_resolve(domain, info):
     except Exception:
         filename = info['module'].replace('.', '/') + '.py'
     tag = 'master' if 'dev' in release else ('v' + release)
-    return "https://github.com/Menelau/DESlib/blob/%s/%s" % (tag, filename)
+    return "https://github.com/scikit-learn-contrib/DESlib/blob/%s/%s" % (tag, filename)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Welcome to DESlib documentation!
 DESlib is an ensemble learning library focusing the implementation of the state-of-the-art techniques for dynamic classifier
 and ensemble selection.
 
-DESlib is a work in progress. Contributions are welcomed through its GitHub page: https://github.com/Menelau/DESlib.
+DESlib is a work in progress. Contributions are welcomed through its GitHub page: https://github.com/scikit-learn-contrib/DESlib.
 
 Introduction
 --------------
@@ -105,4 +105,4 @@ References
 
 .. _scikit-learn: http://scikit-learn.org/stable/
 
-.. _GitHub: https://github.com/Menelau/DESlib
+.. _GitHub: https://github.com/scikit-learn-contrib/DESlib

--- a/docs/user_guide/development.rst
+++ b/docs/user_guide/development.rst
@@ -26,7 +26,7 @@ Reporting Bugs and requesting features
 We use Github issues to track all bugs and feature requests; feel free to
 open an issue if you have found a bug or wish to see a new feature implemented.
 Before opening a new issue, please check if the issue is not being currently addressed:
-[Issues](https://github.com/Menelau/DESlib/issues)
+[Issues](https://github.com/scikit-learn-contrib/DESlib/issues)
 
 For reporting bugs:
 
@@ -72,7 +72,7 @@ Contributing with code
 
 The preferred way to contribute is to fork the main repository to your account:
 
-1. Fork the [project repository](https://github.com/Menelau/DESlib):
+1. Fork the [project repository](https://github.com/scikit-learn-contrib/DESlib):
    click on the 'Fork' button near the top of the page. This creates
    a copy of the code under your account on the GitHub server.
 
@@ -114,6 +114,6 @@ follows PEP8 guidelines.
    the issue and mention the issue number in the pull request description to
    ensure a link is created to the original issue.
 
-.. _GitHub: https://github.com/Menelau/DESlib.
+.. _GitHub: https://github.com/scikit-learn-contrib/DESlib.
 
 .. _scikit-learn: http://scikit-learn.org/stable/


### PR DESCRIPTION
Updating links in the documentation which were pointing to the previous repo URL.