### PR TITLE
Fix label encoder

### DIFF
--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -202,7 +202,7 @@ class APosteriori(BaseDCS):
         # Expanding the dimensions of the predictions and target arrays in
         # order to compare both.
         predictions_3d = np.expand_dims(predictions, axis=1)
-        target_3d = np.expand_dims(self.DSEL_target_[neighbors], axis=2)
+        target_3d = self.DSEL_target_[neighbors, np.newaxis]
 
         # Create a mask to remove the neighbors belonging to a different class
         # than the predicted by the base classifier

--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -112,7 +112,7 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
         return y_ind
 
     def _encode_base_labels(self, y):
-        if not self.base_already_encoded_:
+        if self.base_already_encoded_:
             return y
         else:
             return self.enc_.transform(y)

--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -3,7 +3,7 @@
 # Author: Rafael Menelau Oliveira e Cruz <rafaelmenelau@gmail.com>
 #
 # License: BSD 3 clause
-
+import numpy as np
 from abc import abstractmethod, ABCMeta
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.ensemble import BaseEnsemble, BaggingClassifier
@@ -80,19 +80,26 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
 
         self.n_classifiers_ = len(self.pool_classifiers_)
 
-        # Check if base classifiers are not using LabelEncoder (the case for
-        # scikit-learn's ensembles):
-        if isinstance(self.pool_classifiers_, BaseEnsemble):
-            self.base_already_encoded_ = True
-        else:
-            self.base_already_encoded_ = False
-
+        # dealing with label encoder
+        self.check_label_encoder()
         self.y_enc_ = self._setup_label_encoder(y)
 
         self.n_classes_ = self.classes_.size
         self.n_features_ = X.shape[1]
 
         return self
+
+    def check_label_encoder(self):
+        # Check if base classifiers are not using LabelEncoder (the case for
+        # scikit-learn's ensembles):
+        if isinstance(self.pool_classifiers_, BaseEnsemble):
+            if np.array_equal(self.pool_classifiers_.classes_,
+                              self.pool_classifiers_[0].classes_):
+                self.base_already_encoded_ = False
+            else:
+                self.base_already_encoded_ = True
+        else:
+            self.base_already_encoded_ = False
 
     def _setup_label_encoder(self, y):
         """

--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -103,3 +103,9 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
         self.classes_ = self.enc_.classes_
 
         return y_ind
+
+    def _encode_base_labels(self, y):
+        if not self.base_already_encoded_:
+            return y
+        else:
+            return self.enc_.transform(y)

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -67,7 +67,7 @@ class SingleBest(BaseStaticEnsemble):
         performances = np.zeros(self.n_classifiers_)
         for idx, clf in enumerate(self.pool_classifiers_):
             performances[idx] = clf.score(X, self._encode_base_labels(y))
-        self.best_clf_index_ = np.argmax(idx)
+        self.best_clf_index_ = np.argmax(performances)
         self.best_clf_ = self.pool_classifiers_[self.best_clf_index_]
 
         return self

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -64,13 +64,22 @@ class SingleBest(BaseStaticEnsemble):
 
         super(SingleBest, self).fit(X, y)
 
-        performances = np.zeros(self.n_classifiers_)
-        for idx, clf in enumerate(self.pool_classifiers_):
-            performances[idx] = clf.score(X, self._encode_base_labels(y))
+        if not self.base_already_encoded_:
+            y_encoded = y
+        else:
+            y_encoded = self.enc_.transform(y)
+
+        performances = self._estimate_performances(X, y_encoded)
         self.best_clf_index_ = np.argmax(performances)
         self.best_clf_ = self.pool_classifiers_[self.best_clf_index_]
 
         return self
+
+    def _estimate_performances(self, X, y):
+        performances = np.zeros(self.n_classifiers_)
+        for idx, clf in enumerate(self.pool_classifiers_):
+            performances[idx] = clf.score(X, self._encode_base_labels(y))
+        return performances
 
     def predict(self, X):
         """Predict the label of each sample in X and returns the predicted

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -66,7 +66,7 @@ class SingleBest(BaseStaticEnsemble):
 
         performances = np.zeros(self.n_classifiers_)
         for idx, clf in enumerate(self.pool_classifiers_):
-            performances[idx] = clf.score(X, self.y_enc_)
+            performances[idx] = clf.score(X, self._encode_base_labels(y))
         self.best_clf_index_ = np.argmax(idx)
         self.best_clf_ = self.pool_classifiers_[self.best_clf_index_]
 

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -84,8 +84,13 @@ class StaticSelection(BaseStaticEnsemble):
 
         performances = np.zeros(self.n_classifiers_)
 
+        if not self.base_already_encoded_:
+            y_encoded = y
+        else:
+            y_encoded = self.enc_.transform(y)
+
         for clf_idx, clf in enumerate(self.pool_classifiers_):
-            performances[clf_idx] = clf.score(X, self._encode_base_labels(y))
+            performances[clf_idx] = clf.score(X, y_encoded)
 
         self.clf_indices_ = np.argsort(performances)[::-1][
                             0:self.n_classifiers_ensemble_]
@@ -113,7 +118,7 @@ class StaticSelection(BaseStaticEnsemble):
 
         votes = np.zeros((X.shape[0], self.n_classifiers_ensemble_))
         for clf_index, clf in enumerate(self.ensemble_):
-            votes[:, clf_index] = self.enc_.transform(clf.predict(X))
+            votes[:, clf_index] = self._encode_base_labels(clf.predict(X))
 
         predicted_labels = majority_voting_rule(votes).astype(int)
 

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 from .base import BaseStaticEnsemble
-from deslib.util.aggregation import majority_voting
+from deslib.util.aggregation import majority_voting_rule
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_array
 
 
@@ -110,7 +110,12 @@ class StaticSelection(BaseStaticEnsemble):
         """
         X = check_array(X)
         self._check_is_fitted()
-        predicted_labels = majority_voting(self.ensemble_, X).astype(int)
+
+        votes = np.zeros((X.shape[0], self.n_classifiers_ensemble_))
+        for clf_index, clf in enumerate(self.ensemble_):
+            votes[:, clf_index] = self.enc_.transform(clf.predict(X))
+
+        predicted_labels = majority_voting_rule(votes).astype(int)
 
         return self.classes_.take(predicted_labels)
 

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -85,7 +85,7 @@ class StaticSelection(BaseStaticEnsemble):
         performances = np.zeros(self.n_classifiers_)
 
         for clf_idx, clf in enumerate(self.pool_classifiers_):
-            performances[clf_idx] = clf.score(X, self.y_enc_)
+            performances[clf_idx] = clf.score(X, self._encode_base_labels(y))
 
         self.clf_indices_ = np.argsort(performances)[::-1][
                             0:self.n_classifiers_ensemble_]

--- a/deslib/tests/static/test_single_best.py
+++ b/deslib/tests/static/test_single_best.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.estimator_checks import check_estimator
 
 from deslib.static.single_best import SingleBest
-from sklearn.utils.estimator_checks import check_estimator
 
 
 def test_check_estimator():
@@ -20,10 +20,12 @@ def test_fit(create_X_y, create_pool_classifiers):
 
     pool_classifiers = create_pool_classifiers
     single_best_test = SingleBest(pool_classifiers)
+    single_best_test._estimate_performances = MagicMock(
+        return_value=[1.0, 0.5, 0.99])
+
     single_best_test.fit(X, y)
 
-    assert (single_best_test.best_clf_index_ == 0 or
-            single_best_test.best_clf_index_ == 2)
+    assert single_best_test.best_clf_index_ == 0
 
 
 # The classifier with highest accuracy always predicts 0. So the expected

--- a/deslib/tests/static/test_stacked.py
+++ b/deslib/tests/static/test_stacked.py
@@ -1,7 +1,9 @@
 import pytest
+import numpy as np
 from deslib.static.stacked import StackedClassifier
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.linear_model import Perceptron
+from sklearn.tree import DecisionTreeClassifier
 
 
 def test_check_estimator():
@@ -34,3 +36,12 @@ def test_not_predict_proba_meta(create_X_y, create_pool_classifiers):
                                      meta_classifier=Perceptron())
         meta_clf.fit(X, y)
         meta_clf.predict_proba(X)
+
+
+def test_label_encoder():
+    y = ['one', 'one', 'one', 'zero', 'zero', 'two']
+    X = np.random.rand(6, 3)
+    pool = [DecisionTreeClassifier().fit(X, y) for _ in range(5)]
+    static = StackedClassifier(pool).fit(X, y)
+    pred = static.predict(X)
+    assert np.array_equal(pred, y)

--- a/deslib/tests/static/test_static_selection.py
+++ b/deslib/tests/static/test_static_selection.py
@@ -1,21 +1,14 @@
-from unittest.mock import MagicMock
-
 import numpy as np
 import pytest
 from sklearn.exceptions import NotFittedError
 
 from deslib.static.static_selection import StaticSelection
 from sklearn.utils.estimator_checks import check_estimator
+from sklearn.tree import DecisionTreeClassifier
 
 
 def test_check_estimator():
     check_estimator(StaticSelection)
-
-#
-# def create_example_static(create_X_y):
-#     for clf in pool:
-#         clf.score = MagicMock(return_value=score)
-#     return pool
 
 
 # Testing if the fit function selects the correct classifiers.
@@ -71,3 +64,12 @@ def test_invalid_pct2():
     with pytest.raises(ValueError):
         test = StaticSelection(pct_classifiers=1.2)
         test.fit(np.random.rand(10, 2), np.ones(10))
+
+
+def test_label_encoder():
+    y = ['one', 'one', 'one', 'zero', 'zero', 'two']
+    X = np.random.rand(6, 3)
+    pool = [DecisionTreeClassifier().fit(X, y) for _ in range(5)]
+    static = StaticSelection(pool).fit(X, y)
+    pred = static.predict(X)
+    assert np.array_equal(pred, y)

--- a/deslib/tests/static/test_static_selection.py
+++ b/deslib/tests/static/test_static_selection.py
@@ -5,7 +5,6 @@ from sklearn.exceptions import NotFittedError
 from deslib.static.static_selection import StaticSelection
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.ensemble import AdaBoostClassifier
 
 
 def test_check_estimator():

--- a/deslib/tests/static/test_static_selection.py
+++ b/deslib/tests/static/test_static_selection.py
@@ -5,6 +5,7 @@ from sklearn.exceptions import NotFittedError
 from deslib.static.static_selection import StaticSelection
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import AdaBoostClassifier
 
 
 def test_check_estimator():

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -321,7 +321,7 @@ def test_single_best():
 
     single_best = SingleBest(pool_classifiers)
     single_best.fit(X_dsel, y_dsel)
-    assert np.isclose(single_best.score(X_test, y_test), 0.97872340425531912)
+    assert np.isclose(single_best.score(X_test, y_test), 0.9680851063829787)
 
 
 def test_static_selection():

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -2,6 +2,7 @@ import numpy as np
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.datasets import load_breast_cancer
 from sklearn.ensemble import BaggingClassifier
+from sklearn.ensemble import AdaBoostClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.linear_model import Perceptron
 from sklearn.model_selection import train_test_split
@@ -84,6 +85,21 @@ def test_label_encoder_integration_sklearn_ensembles():
     knorau = KNORAU(pool_classifiers)
     knorau.fit(X_dsel, y_dsel)
     assert np.isclose(knorau.score(X_test, y_test), 0.97340425531914898)
+
+
+def test_label_encoder_integration_sklearn_ensembles_not_encoding():
+
+    rng = np.random.RandomState(123456)
+    X_dsel, X_test, X_train, y_dsel, y_test, y_train = load_dataset(
+        ['yes', 'no'], rng)
+
+    # Train a pool of using adaboost which has label encoding problems.
+    pool_classifiers = AdaBoostClassifier(n_estimators=10, random_state=rng)
+    pool_classifiers.fit(X_train, y_train)
+
+    knorau = KNORAU(pool_classifiers)
+    knorau.fit(X_dsel, y_dsel)
+    assert np.isclose(knorau.score(X_test, y_test), 0.9521276595744681)
 
 
 def setup_classifiers(encode_labels=None):


### PR DESCRIPTION
- Fix problem with label encoding on StaticSelection (issue #176 );
- Update heuristic used to detect whether the base classifiers already encode the labels for scikit-learn ensemble models (fix the problem with AdaBoostClassifier in the new sklearn versions);
- Fix error on the SingleBest model not selecting the classifier with the highest performance in some cases.