### PR TITLE
Label encoder static

### DIFF
--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -89,7 +89,7 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
 
         self._validate_pool()
         # dealing with label encoder
-        self.check_label_encoder()
+        self._check_label_encoder()
         self.y_enc_ = self._setup_label_encoder(y)
 
         self.n_classes_ = self.classes_.size
@@ -97,7 +97,7 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
 
         return self
 
-    def check_label_encoder(self):
+    def _check_label_encoder(self):
         # Check if base classifiers are not using LabelEncoder (the case for
         # scikit-learn's ensembles):
         if isinstance(self.pool_classifiers_, BaseEnsemble):

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -113,7 +113,7 @@ class SingleBest(BaseStaticEnsemble):
         X = check_array(X)
         self._check_is_fitted()
         predicted_labels = self._encode_base_labels(self.best_clf_.predict(X))
-        return self.classes_.take(predicted_labels)
+        return self.classes_.take(predicted_labels.astype(np.int))
 
     def predict_proba(self, X):
         """Estimates the posterior probabilities for each class for each sample

--- a/deslib/tests/static/test_oracle.py
+++ b/deslib/tests/static/test_oracle.py
@@ -62,5 +62,5 @@ def test_label_encoder_base_ensemble():
     pool = RandomForestClassifier().fit(X, y)
     oracle = Oracle(pool)
     oracle.fit(X, y)
-    pred = oracle.predict(X)
+    pred = oracle.predict(X, y)
     assert np.isin(oracle.classes_, pred).all()

--- a/deslib/tests/static/test_oracle.py
+++ b/deslib/tests/static/test_oracle.py
@@ -1,8 +1,8 @@
 import numpy as np
-
-from deslib.static.oracle import Oracle
 from sklearn.datasets import make_classification
 from sklearn.ensemble import RandomForestClassifier
+
+from deslib.static.oracle import Oracle
 
 
 def test_predict(create_X_y, create_pool_classifiers):
@@ -52,3 +52,15 @@ def test_predict_proba_right_class():
     proba = oracle.predict_proba(X_test, y_test)
     probas_max = np.argmax(proba, axis=1)
     assert np.allclose(probas_max, preds)
+
+
+def test_label_encoder_base_ensemble():
+    from sklearn.ensemble import RandomForestClassifier
+    X, y = make_classification()
+    y[y == 1] = 2
+    y = y.astype(np.float)
+    pool = RandomForestClassifier().fit(X, y)
+    oracle = Oracle(pool)
+    oracle.fit(X, y)
+    pred = oracle.predict(X)
+    assert np.isin(oracle.classes_, pred).all()

--- a/deslib/tests/static/test_single_best.py
+++ b/deslib/tests/static/test_single_best.py
@@ -84,6 +84,18 @@ def test_label_encoder(create_label_encoder_test):
     assert np.array_equal(pred, y)
 
 
+def test_label_encoder_base_ensemble():
+    from sklearn.ensemble import RandomForestClassifier
+    X, y = make_classification()
+    y[y == 1] = 2
+    y = y.astype(np.float)
+    pool = RandomForestClassifier().fit(X, y)
+    sb = SingleBest(pool)
+    sb.fit(X, y)
+    pred = sb.predict(X)
+    assert np.isin(sb.classes_, pred).all()
+
+
 def test_different_scorer():
     X, y = make_classification(n_samples=100, random_state=42)
     X_val, y_val = make_classification(n_samples=25, random_state=123)

--- a/deslib/tests/static/test_stacked.py
+++ b/deslib/tests/static/test_stacked.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from sklearn.datasets import make_classification
 from sklearn.linear_model import Perceptron
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.estimator_checks import check_estimator
@@ -46,6 +47,18 @@ def test_label_encoder():
     stacked = StackedClassifier(pool).fit(X, y)
     pred = stacked.predict(X)
     assert np.array_equal(pred, y)
+
+
+def test_label_encoder_base_ensemble():
+    from sklearn.ensemble import RandomForestClassifier
+    X, y = make_classification()
+    y[y == 1] = 2
+    y = y.astype(np.float)
+    pool = RandomForestClassifier().fit(X, y)
+    st = StackedClassifier(pool)
+    st.fit(X, y)
+    pred = st.predict(X)
+    assert np.isin(st.classes_, pred).all()
 
 
 def test_one_class_meta_dataset(create_X_y):

--- a/deslib/tests/static/test_static_selection.py
+++ b/deslib/tests/static/test_static_selection.py
@@ -75,6 +75,18 @@ def test_label_encoder(create_label_encoder_test):
     assert np.array_equal(pred, y)
 
 
+def test_label_encoder_base_ensemble():
+    from sklearn.ensemble import RandomForestClassifier
+    X, y = make_classification()
+    y[y == 1] = 2
+    y = y.astype(np.float)
+    pool = RandomForestClassifier().fit(X, y)
+    ss = StaticSelection(pool)
+    ss.fit(X, y)
+    pred = ss.predict(X)
+    assert np.isin(ss.classes_, pred).all()
+
+
 def test_predict_proba(example_static_selection):
     X, y, pool = example_static_selection
     expected = np.tile([0.52, 0.48], (y.size, 1))


### PR DESCRIPTION
Fixing label encoder problem in the SingleBest model. The problem appears in a very specific scenario where the pool of classifiers is a BaseEnsemble from sklearn (e.g., RandomForestClassifier, BaggingClassifier) and the base models are already using label encoder (however having classes as float instead of integers).

This PR fixes #221 