### PR TITLE
Adding newer python versions to travis.ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   python3:
     docker:
       # specify the version you desire here
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.9
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
     environment:
       - USERNAME: "Menelau"
@@ -33,7 +33,7 @@ jobs:
             chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
             export PATH="~/miniconda/bin:$PATH"
             conda update --yes --quiet conda
-            conda create -n testenv --yes --quiet python=3.6
+            conda create -n testenv --yes --quiet python=3.9u
             source activate testenv
             conda install --yes pip numpy
             pip install -r requirements-dev.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - checkout
       - run:
+          no_output_timeout: 30m
           command: |
             wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
             chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             chmod +x miniconda.sh && ./miniconda.sh -b -p ~/miniconda
             export PATH="~/miniconda/bin:$PATH"
             conda update --yes --quiet conda
-            conda create -n testenv --yes --quiet python=3.9u
+            conda create -n testenv --yes --quiet python=3.9
             source activate testenv
             conda install --yes pip numpy
             pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
   - "3.8"
   - "3.9"
-
-# Python 3.7 workaround https://github.com/travis-ci/travis-ci/issues/9815
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
 
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry python setup.py build
   - travis_retry python setup.py install
   # Faiss requires anaconda and only works for python 3.5 and 3.6:
-  - if [[ "$TRAVIS_PYTHON_VERSION" != "3.7" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" < "3.9" ]]; then
       travis_retry conda install faiss-cpu -c pytorch;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - travis_retry python setup.py build
   - travis_retry python setup.py install
   # Faiss requires anaconda and only works for python 3.5 and 3.6:
-  - if [[ "$TRAVIS_PYTHON_VERSION" < "3.7" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" != "3.7" ]]; then
       travis_retry conda install faiss-cpu -c pytorch;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.8"
+  - "3.9"
 
 # Python 3.7 workaround https://github.com/travis-ci/travis-ci/issues/9815
 matrix:
@@ -8,6 +10,7 @@ matrix:
     - python: "3.7"
       dist: xenial
       sudo: true
+
 install:
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -22,7 +25,7 @@ install:
   - travis_retry python setup.py build
   - travis_retry python setup.py install
   # Faiss requires anaconda and only works for python 3.5 and 3.6:
-  - if [[ "$TRAVIS_PYTHON_VERSION" != "3.7" ]]; then
+  - if [[ "$TRAVIS_PYTHON_VERSION" < "3.7" ]]; then
       travis_retry conda install faiss-cpu -c pytorch;
     fi
 


### PR DESCRIPTION
- Addition of python 3.8 and 3.9 builds
- Conducting FAISS tests with supported python versions (<3.9)
