### PR TITLE
Refactor flow base methods

### DIFF
--- a/deslib/base.py
+++ b/deslib/base.py
@@ -85,7 +85,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         pass
 
     @abstractmethod
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}`
         the classification of the query sample :math:`\\mathbf{x}`.
@@ -95,9 +95,6 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The query sample
-
         neighbors : array of shape (n_samples, n_neighbors)
                     Indices of the k nearest neighbors according for each
                     test sample.
@@ -116,16 +113,13 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         pass
 
     @abstractmethod
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self,predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
         Returns the predicted label.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples
 
@@ -151,16 +145,13 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         pass
 
     @abstractmethod
-    def predict_proba_with_ds(self, query, predictions, probabilities,
+    def predict_proba_with_ds(self, predictions, probabilities,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding
         query sample. Returns the probability estimates of each class.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples
 
@@ -418,7 +409,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
                 inds, sel_preds, sel_probas = self._prepare_indices_DS(
                     base_preds, base_probas, ind_disagreement,
                     ind_ds_classifier)
-                preds_ds = self.classify_with_ds(None, sel_preds, sel_probas,
+                preds_ds = self.classify_with_ds(sel_preds, sel_probas,
                                                  neighbors, distances,
                                                  DFP_mask)
                 preds[inds] = preds_ds

--- a/deslib/base.py
+++ b/deslib/base.py
@@ -449,7 +449,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
                 inds, sel_preds, sel_probas = self._prepare_indices_DS(
                     base_preds, base_probas, ind_disagreement,
                     ind_ds_classifier)
-                probas_ds = self.predict_proba_with_ds(None, sel_preds,
+                probas_ds = self.predict_proba_with_ds(sel_preds,
                                                        sel_probas,
                                                        neighbors, distances,
                                                        DFP_mask)

--- a/deslib/base.py
+++ b/deslib/base.py
@@ -352,7 +352,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
         self.roc_algorithm_ = self.knn_class_(n_neighbors=self.k)
 
-    def _get_region_competence(self, query, k=None):
+    def get_region_competence(self, query, k=None):
         """Compute the region of competence of the query sample
         using the data belonging to DSEL.
 
@@ -482,7 +482,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
     def _IH_prediction(self, X, ind_disagree, predicted_proba, is_proba=False):
         X_DS = X[ind_disagree, :]
-        distances, region_competence = self._get_region_competence(X_DS)
+        distances, region_competence = self.get_region_competence(X_DS)
         if self.with_IH:
             ind_hard, ind_easy = self._split_easy_samples(region_competence)
             distances, region_competence = self._predict_easy_samples(

--- a/deslib/base.py
+++ b/deslib/base.py
@@ -85,7 +85,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         pass
 
     @abstractmethod
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}`
         the classification of the query sample :math:`\\mathbf{x}`.
@@ -95,7 +95,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
                     Indices of the k nearest neighbors according for each
                     test sample.
 
@@ -343,7 +343,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
         self.roc_algorithm_ = self.knn_class_(n_neighbors=self.k)
 
-    def get_region_competence(self, query, k=None):
+    def get_competence_region(self, query, k=None):
         """Compute the region of competence of the query sample
         using the data belonging to DSEL.
 
@@ -473,7 +473,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
 
     def _IH_prediction(self, X, ind_disagree, predicted_proba, is_proba=False):
         X_DS = X[ind_disagree, :]
-        distances, region_competence = self.get_region_competence(X_DS)
+        distances, region_competence = self.get_competence_region(X_DS)
         if self.with_IH:
             ind_hard, ind_easy = self._split_easy_samples(region_competence)
             distances, region_competence = self._predict_easy_samples(

--- a/deslib/base.py
+++ b/deslib/base.py
@@ -129,10 +129,9 @@ class BaseDS(BaseEstimator, ClassifierMixin):
             base classifiers)
 
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -161,10 +160,9 @@ class BaseDS(BaseEstimator, ClassifierMixin):
             classifiers).
 
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
            Mask containing 1 for the selected base classifier and 0 otherwise.

--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -156,7 +156,7 @@ class APosteriori(BaseDCS):
         self.dsel_scores_ = self._predict_proba_base(self.DSEL_data_)
         return self
 
-    def estimate_competence(self, neighbors, distances,
+    def estimate_competence(self, competence_region, distances,
                             predictions=None):
         """Estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the A Posteriori method.
@@ -180,7 +180,7 @@ class APosteriori(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -206,7 +206,7 @@ class APosteriori(BaseDCS):
         # Expanding the dimensions of the predictions and target arrays in
         # order to compare both.
         predictions_3d = np.expand_dims(predictions, axis=1)
-        target_3d = self.DSEL_target_[neighbors, np.newaxis]
+        target_3d = self.DSEL_target_[competence_region, np.newaxis]
 
         # Create a mask to remove the neighbors belonging to a different class
         # than the predicted by the base classifier
@@ -219,8 +219,8 @@ class APosteriori(BaseDCS):
 
         # Multiply the pre-processed correct predictions by the base
         # classifiers to the distance array
-        scores_target = self.dsel_scores_[neighbors, :,
-                                          self.DSEL_target_[neighbors]]
+        scores_target = self.dsel_scores_[competence_region, :,
+                                          self.DSEL_target_[competence_region]]
         scores_target_norm = scores_target * dists_normalized
 
         # Create masked arrays to remove samples with different label in the

--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -181,10 +181,10 @@ class APosteriori(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -156,7 +156,7 @@ class APosteriori(BaseDCS):
         self.dsel_scores_ = self._predict_proba_base(self.DSEL_data_)
         return self
 
-    def estimate_competence(self, query, neighbors, distances,
+    def estimate_competence(self, neighbors, distances,
                             predictions=None):
         """Estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the A Posteriori method.
@@ -180,9 +180,6 @@ class APosteriori(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -184,7 +184,7 @@ class APosteriori(BaseDCS):
             Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -150,7 +150,7 @@ class APriori(BaseDCS):
         self.dsel_scores_ = self._predict_proba_base(self.DSEL_data_)
         return self
 
-    def estimate_competence(self, neighbors, distances,
+    def estimate_competence(self, competence_region, distances,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the A Priori rule:
@@ -172,7 +172,7 @@ class APriori(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -192,8 +192,8 @@ class APriori(BaseDCS):
 
         # Get the ndarray containing the scores obtained for the correct class
         # for each neighbor (and test sample)
-        scores_target_class = self.dsel_scores_[neighbors, :,
-                                                self.DSEL_target_[neighbors]]
+        scores_target_class = self.dsel_scores_[competence_region, :,
+                                                self.DSEL_target_[competence_region]]
 
         # Multiply the scores obtained for the correct class to the distances
         # of each corresponding neighbor

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -150,7 +150,7 @@ class APriori(BaseDCS):
         self.dsel_scores_ = self._predict_proba_base(self.DSEL_data_)
         return self
 
-    def estimate_competence(self, query, neighbors, distances,
+    def estimate_competence(self, neighbors, distances,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the A Priori rule:
@@ -172,9 +172,6 @@ class APriori(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -173,10 +173,10 @@ class APriori(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/base.py
+++ b/deslib/dcs/base.py
@@ -185,7 +185,7 @@ class BaseDCS(BaseDS):
         """
         if predictions.ndim < 2:
             predictions = predictions.reshape(1, -1)
-        competences = self.estimate_competence(query, neighbors,
+        competences = self.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=predictions)
 
@@ -239,7 +239,7 @@ class BaseDCS(BaseDS):
         predicted_proba: array of shape (n_samples, n_classes)
             Posterior probabilities estimates for each test example.
         """
-        competences = self.estimate_competence(query, neighbors,
+        competences = self.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=predictions)
 

--- a/deslib/dcs/base.py
+++ b/deslib/dcs/base.py
@@ -36,14 +36,14 @@ class BaseDCS(BaseDS):
         self.selection_method = selection_method
         self.diff_thresh = diff_thresh
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """Estimate the competence of each base classifier for the
         classification of the query sample.
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)

--- a/deslib/dcs/base.py
+++ b/deslib/dcs/base.py
@@ -36,16 +36,13 @@ class BaseDCS(BaseDS):
         self.selection_method = selection_method
         self.diff_thresh = diff_thresh
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """Estimate the competence of each base classifier for the
         classification of the query sample.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
@@ -154,7 +151,7 @@ class BaseDCS(BaseDS):
 
         return selected_classifiers
 
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the class label of the corresponding query sample.
 
@@ -164,9 +161,6 @@ class BaseDCS(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples
 
@@ -189,19 +183,8 @@ class BaseDCS(BaseDS):
         predicted_label : array of shape (n_samples)
             The predicted label for each query
         """
-        # if query.ndim < 2:
-        #     query = query.reshape(1, -1)
-
         if predictions.ndim < 2:
             predictions = predictions.reshape(1, -1)
-
-        # if query.shape[0] != predictions.shape[0]:
-        #     raise ValueError(
-        #         'The arrays query and predictions must have the same shape. '
-        #         'query.shape is {}'
-        #         'and predictions.shape is {}'.format(query.shape,
-        #                                              predictions.shape))
-
         competences = self.estimate_competence(query, neighbors,
                                                distances=distances,
                                                predictions=predictions)
@@ -223,7 +206,7 @@ class BaseDCS(BaseDS):
 
         return predicted_label
 
-    def predict_proba_with_ds(self, query, predictions, probabilities,
+    def predict_proba_with_ds(self, predictions, probabilities,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding query
         sample.
@@ -234,9 +217,6 @@ class BaseDCS(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples
 
@@ -259,13 +239,6 @@ class BaseDCS(BaseDS):
         predicted_proba: array of shape (n_samples, n_classes)
             Posterior probabilities estimates for each test example.
         """
-        # if query.shape[0] != probabilities.shape[0]:
-        #     raise ValueError(
-        #         'The arrays query and predictions must have the same number '
-        #         'of samples. query.shape is {}'
-        #         'and predictions.shape is {}'.format(query.shape,
-        #                                              predictions.shape))
-
         competences = self.estimate_competence(query, neighbors,
                                                distances=distances,
                                                predictions=predictions)

--- a/deslib/dcs/base.py
+++ b/deslib/dcs/base.py
@@ -44,10 +44,10 @@ class BaseDCS(BaseDS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.
@@ -170,10 +170,9 @@ class BaseDCS(BaseDS):
             base classifiers)
 
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -226,10 +225,9 @@ class BaseDCS(BaseDS):
             classifiers).
 
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
            Mask containing 1 for the selected base classifier and 0 otherwise.

--- a/deslib/dcs/lca.py
+++ b/deslib/dcs/lca.py
@@ -125,7 +125,7 @@ class LCA(BaseDCS):
                                   knne=knne,
                                   n_jobs=n_jobs)
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the local class accuracy
@@ -149,7 +149,7 @@ class LCA(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -169,12 +169,12 @@ class LCA(BaseDCS):
         # Expanding the dimensions of the predictions and target arrays in
         # order to compare both.
         predictions_3d = np.expand_dims(predictions, axis=1)
-        target_3d = np.expand_dims(self.DSEL_target_[neighbors], axis=2)
+        target_3d = np.expand_dims(self.DSEL_target_[competence_region], axis=2)
         # Create a mask to remove the neighbors belonging to a different class
         # than the predicted by the base classifier
         mask = (predictions_3d != target_3d)
         masked_preprocessed = np.ma.MaskedArray(
-            self.DSEL_processed_[neighbors, :], mask=mask)
+            self.DSEL_processed_[competence_region, :], mask=mask)
 
         competences_masked = np.mean(masked_preprocessed, axis=1)
         # Fill 0 to the masked values in the resulting array (when no neighbors

--- a/deslib/dcs/lca.py
+++ b/deslib/dcs/lca.py
@@ -125,7 +125,7 @@ class LCA(BaseDCS):
                                   knne=knne,
                                   n_jobs=n_jobs)
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the local class accuracy
@@ -149,9 +149,6 @@ class LCA(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/lca.py
+++ b/deslib/dcs/lca.py
@@ -150,10 +150,10 @@ class LCA(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/mcb.py
+++ b/deslib/dcs/mcb.py
@@ -137,7 +137,7 @@ class MCB(BaseDCS):
 
         self.similarity_threshold = similarity_threshold
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the Multiple Classifier
@@ -170,9 +170,6 @@ class MCB(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/mcb.py
+++ b/deslib/dcs/mcb.py
@@ -171,10 +171,10 @@ class MCB(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/mcb.py
+++ b/deslib/dcs/mcb.py
@@ -137,7 +137,7 @@ class MCB(BaseDCS):
 
         self.similarity_threshold = similarity_threshold
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the Multiple Classifier
@@ -170,7 +170,7 @@ class MCB(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -189,9 +189,9 @@ class MCB(BaseDCS):
         # Use the pre-compute decisions to transform the query to the BKS space
         BKS_query = predictions
 
-        T = (self.BKS_DSEL_[neighbors] == BKS_query.reshape(BKS_query.shape[0],
-                                                            -1,
-                                                            BKS_query.shape[
+        T = (self.BKS_DSEL_[competence_region] == BKS_query.reshape(BKS_query.shape[0],
+                                                                    -1,
+                                                                    BKS_query.shape[
                                                                 1]))
         S = np.sum(T, axis=2) / self.n_classifiers_
 
@@ -205,7 +205,7 @@ class MCB(BaseDCS):
                                  self.n_classifiers_, axis=2)
 
         # Use the masked array mean to take into account the removed neighbors
-        processed_pred = np.ma.MaskedArray(self.DSEL_processed_[neighbors, :],
+        processed_pred = np.ma.MaskedArray(self.DSEL_processed_[competence_region, :],
                                            mask=~boolean_mask)
         competences = np.ma.mean(processed_pred, axis=1)
 

--- a/deslib/dcs/mla.py
+++ b/deslib/dcs/mla.py
@@ -123,7 +123,7 @@ class MLA(BaseDCS):
                                   DSEL_perc=DSEL_perc,
                                   n_jobs=n_jobs)
 
-    def estimate_competence(self, neighbors, distances,
+    def estimate_competence(self, competence_region, distances,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the Modified Local
@@ -147,7 +147,7 @@ class MLA(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -171,7 +171,7 @@ class MLA(BaseDCS):
         # Expanding the dimensions of the predictions and target arrays in
         # order to compare both.
         predictions_3d = np.expand_dims(predictions, axis=1)
-        target_3d = np.expand_dims(self.DSEL_target_[neighbors], axis=2)
+        target_3d = np.expand_dims(self.DSEL_target_[competence_region], axis=2)
         # Create a mask to remove the neighbors belonging to a different class
         # than the predicted by the base classifier
         mask = (predictions_3d != target_3d)
@@ -183,7 +183,7 @@ class MLA(BaseDCS):
 
         # Multiply the pre-processed correct predictions by the base
         # classifiers to the distance array
-        proc_norm = self.DSEL_processed_[neighbors, :] * dists_normalized
+        proc_norm = self.DSEL_processed_[competence_region, :] * dists_normalized
 
         # Create masked arrays to remove samples with different label in the
         # calculations

--- a/deslib/dcs/mla.py
+++ b/deslib/dcs/mla.py
@@ -123,7 +123,7 @@ class MLA(BaseDCS):
                                   DSEL_perc=DSEL_perc,
                                   n_jobs=n_jobs)
 
-    def estimate_competence(self, query, neighbors, distances,
+    def estimate_competence(self, neighbors, distances,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample using the Modified Local
@@ -147,9 +147,6 @@ class MLA(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/mla.py
+++ b/deslib/dcs/mla.py
@@ -148,10 +148,10 @@ class MLA(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/ola.py
+++ b/deslib/dcs/ola.py
@@ -122,7 +122,7 @@ class OLA(BaseDCS):
                                   knne=knne,
                                   DSEL_perc=DSEL_perc, n_jobs=n_jobs)
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -140,9 +140,6 @@ class OLA(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/ola.py
+++ b/deslib/dcs/ola.py
@@ -122,7 +122,7 @@ class OLA(BaseDCS):
                                   knne=knne,
                                   DSEL_perc=DSEL_perc, n_jobs=n_jobs)
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -140,7 +140,7 @@ class OLA(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -155,6 +155,6 @@ class OLA(BaseDCS):
             Competence level estimated for each base classifier and test
             example.
         """
-        competences = np.mean(self.DSEL_processed_[neighbors, :], axis=1)
+        competences = np.mean(self.DSEL_processed_[competence_region, :], axis=1)
 
         return competences

--- a/deslib/dcs/ola.py
+++ b/deslib/dcs/ola.py
@@ -141,10 +141,10 @@ class OLA(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/dcs/rank.py
+++ b/deslib/dcs/rank.py
@@ -129,7 +129,7 @@ class Rank(BaseDCS):
                                    DSEL_perc=DSEL_perc,
                                    n_jobs=n_jobs)
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample using the modified ranking
@@ -139,9 +139,6 @@ class Rank(BaseDCS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-            The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/dcs/rank.py
+++ b/deslib/dcs/rank.py
@@ -129,7 +129,7 @@ class Rank(BaseDCS):
                                    DSEL_perc=DSEL_perc,
                                    n_jobs=n_jobs)
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample using the modified ranking
@@ -139,7 +139,7 @@ class Rank(BaseDCS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -154,7 +154,7 @@ class Rank(BaseDCS):
             Competence level estimated for each base classifier and test
             example.
         """
-        results_neighbors = self.DSEL_processed_[neighbors, :]
+        results_neighbors = self.DSEL_processed_[competence_region, :]
 
         # Get the shape of the vector in order to know the number of samples,
         # base classifiers and neighbors considered.

--- a/deslib/dcs/rank.py
+++ b/deslib/dcs/rank.py
@@ -140,10 +140,10 @@ class Rank(BaseDCS):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for the test examples.

--- a/deslib/des/base.py
+++ b/deslib/des/base.py
@@ -39,7 +39,8 @@ class BaseDES(BaseDS):
         self.voting = voting
 
     def classify_with_ds(self, predictions, probabilities=None,
-                         neighbors=None, distances=None, DFP_mask=None):
+                         competence_region=None, distances=None,
+                         DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         If self.mode == "selection", the selected ensemble is combined using
@@ -66,12 +67,11 @@ class BaseDES(BaseDS):
             examples. (For methods that always require probabilities from
             the base classifiers).
 
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+                        Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -82,11 +82,13 @@ class BaseDES(BaseDS):
                           Predicted class label for each test example.
         """
         probas = self.predict_proba_with_ds(predictions, probabilities,
-                                            neighbors, distances, DFP_mask)
+                                            competence_region, distances,
+                                            DFP_mask)
         return probas.argmax(axis=1)
 
     def predict_proba_with_ds(self, predictions, probabilities=None,
-                              neighbors=None, distances=None, DFP_mask=None):
+                              competence_region=None, distances=None,
+                              DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding query.
 
         If self.mode == "selection", the selected ensemble is used to estimate
@@ -111,11 +113,10 @@ class BaseDES(BaseDS):
         probabilities : array of shape (n_samples, n_classifiers, n_classes)
             Probabilities estimates of each base classifier for all samples.
 
-        neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+        competence_region : array of shape (n_samples, n_neighbors)
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -127,13 +128,14 @@ class BaseDES(BaseDS):
         """
         if self.needs_proba:
             competences = self.estimate_competence_from_proba(
-                neighbors=neighbors,
+                neighbors=competence_region,
                 distances=distances,
                 probabilities=probabilities)
         else:
-            competences = self.estimate_competence(competence_region=neighbors,
-                                                   distances=distances,
-                                                   predictions=predictions)
+            competences = self.estimate_competence(
+                competence_region=competence_region,
+                distances=distances,
+                predictions=predictions)
         if self.DFP:
             # FIRE-DES pruning.
             competences = competences * DFP_mask

--- a/deslib/des/base.py
+++ b/deslib/des/base.py
@@ -38,81 +38,6 @@ class BaseDES(BaseDS):
         self.mode = mode
         self.voting = voting
 
-    def estimate_competence(self, neighbors, distances=None,
-                            predictions=None):
-        """Estimate the competence of each base classifier :math:`c_{i}`
-        the classification of the query sample x.
-        Returns an array containing the level of competence estimated
-        for each base classifier. The size of the vector is equals to
-        the size of the generated_pool of classifiers.
-
-        Parameters
-        ----------
-        neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
-        distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
-
-        predictions : array of shape (n_samples, n_classifiers)
-            Predictions of the base classifiers for the test examples.
-
-        Returns
-        -------
-        competences : array of shape (n_samples, n_classifiers)
-            Competence level estimated for each base classifier and test
-            example.
-        """
-        pass
-
-    def estimate_competence_from_proba(self, neighbors, probabilities,
-                                       distances=None):
-        """ estimate the competence of each base classifier :math:`c_{i}`
-        the classification of the query sample x, for methods that require
-        probabilities.
-
-        Returns an array containing the level of competence estimated
-        for each base classifier. The size of the vector is equals to
-        the size of the generated_pool of classifiers.
-
-        Parameters
-        ----------
-        neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample.
-
-        distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
-
-        probabilities : array of shape (n_samples, n_classifiers, n_classes)
-            Probabilities estimates of each base classifier for all samples.
-
-        Returns
-        -------
-        competences : array = [n_samples, n_classifiers]
-            Competence level estimated for each base classifier and test
-            example.
-        """
-        pass
-
-    def select(self, competences):
-        """Select the most competent classifiers to compose an ensemble for
-        the classification of the query sample X.
-
-        Parameters
-        ----------
-        competences : array of shape (n_samples, n_classifiers)
-            Estimated competence level of each base classifier for each test
-            example.
-
-        Returns
-        -------
-        selected_classifiers : array of shape (n_samples, n_classifiers)
-            Boolean matrix containing True if the base classifier is selected.
-            False otherwise.
-        """
-        pass
-
     def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
@@ -206,7 +131,7 @@ class BaseDES(BaseDS):
                 distances=distances,
                 probabilities=probabilities)
         else:
-            competences = self.estimate_competence(neighbors=neighbors,
+            competences = self.estimate_competence(competence_region=neighbors,
                                                    distances=distances,
                                                    predictions=predictions)
         if self.DFP:

--- a/deslib/des/base.py
+++ b/deslib/des/base.py
@@ -38,7 +38,7 @@ class BaseDES(BaseDS):
         self.mode = mode
         self.voting = voting
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """Estimate the competence of each base classifier :math:`c_{i}`
         the classification of the query sample x.
@@ -48,9 +48,6 @@ class BaseDES(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
@@ -68,7 +65,7 @@ class BaseDES(BaseDS):
         """
         pass
 
-    def estimate_competence_from_proba(self, query, neighbors, probabilities,
+    def estimate_competence_from_proba(self, neighbors, probabilities,
                                        distances=None):
         """ estimate the competence of each base classifier :math:`c_{i}`
         the classification of the query sample x, for methods that require
@@ -80,9 +77,6 @@ class BaseDES(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The query sample.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
@@ -119,7 +113,7 @@ class BaseDES(BaseDS):
         """
         pass
 
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
@@ -139,9 +133,6 @@ class BaseDES(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
                       Predictions of the base classifier for all test examples.
 
@@ -165,11 +156,11 @@ class BaseDES(BaseDS):
         predicted_label : array of shape (n_samples)
                           Predicted class label for each test example.
         """
-        probas = self.predict_proba_with_ds(query, predictions, probabilities,
+        probas = self.predict_proba_with_ds(predictions, probabilities,
                                             neighbors, distances, DFP_mask)
         return probas.argmax(axis=1)
 
-    def predict_proba_with_ds(self, query, predictions, probabilities=None,
+    def predict_proba_with_ds(self, predictions, probabilities=None,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding query.
 
@@ -189,9 +180,6 @@ class BaseDES(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifier for all test examples.
 
@@ -214,13 +202,11 @@ class BaseDES(BaseDS):
         """
         if self.needs_proba:
             competences = self.estimate_competence_from_proba(
-                query,
                 neighbors=neighbors,
                 distances=distances,
                 probabilities=probabilities)
         else:
-            competences = self.estimate_competence(query,
-                                                   neighbors=neighbors,
+            competences = self.estimate_competence(neighbors=neighbors,
                                                    distances=distances,
                                                    predictions=predictions)
         if self.DFP:

--- a/deslib/des/des_clustering.py
+++ b/deslib/des/des_clustering.py
@@ -279,7 +279,8 @@ class DESClustering(BaseDS):
         return selected_classifiers
 
     def classify_with_ds(self, predictions, probabilities=None,
-                         neighbors=None, distances=None, DFP_mask=None):
+                         competence_region=None, distances=None,
+                         DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
@@ -291,12 +292,11 @@ class DESClustering(BaseDS):
             Probabilities estimates of each base classifier for all test
             examples.
 
-        neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample.
+        competence_region : array of shape (n_samples)
+            Indices of the nearest clusters to each sample.
 
-        distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+        distances : array of shape (n_samples)
+            Distances of the nearest clusters to each sample.
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -307,12 +307,14 @@ class DESClustering(BaseDS):
                           Predicted class label for each test example.
         """
         proba = self.predict_proba_with_ds(predictions, probabilities,
-                                           neighbors, distances, DFP_mask)
+                                           competence_region, distances,
+                                           DFP_mask)
         predicted_label = proba.argmax(axis=1)
         return predicted_label
 
     def predict_proba_with_ds(self, predictions, probabilities,
-                              neighbors=None, distances=None, DFP_mask=None):
+                              competence_region=None, distances=None,
+                              DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
@@ -324,11 +326,11 @@ class DESClustering(BaseDS):
             Probabilities estimates of each base classifier for all test
             examples.
 
-        neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample.
+        competence_region : array of shape (n_samples)
+            Indices of the nearest clusters to each sample.
 
-        distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+        distances : array of shape (n_samples)
+            Distances of the nearest clusters to each sample.
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -338,7 +340,7 @@ class DESClustering(BaseDS):
         predicted_proba : array of shape (n_samples, n_classes)
             Posterior probabilities estimates for each test example.
         """
-        selected_classifiers = self.select(neighbors)
+        selected_classifiers = self.select(competence_region)
 
         if self.voting == 'hard':
             votes = predictions[np.arange(predictions.shape[0])[:, None],

--- a/deslib/des/des_clustering.py
+++ b/deslib/des/des_clustering.py
@@ -179,7 +179,7 @@ class DESClustering(BaseDS):
         self._preprocess_clusters()
         return self
 
-    def get_region_competence(self, query, k=None):
+    def get_competence_region(self, query, k=None):
         distances = self.clustering_.transform(query.astype(np.double))
         region = self.clustering_.predict(query.astype(np.double))
         return distances, region
@@ -233,7 +233,7 @@ class DESClustering(BaseDS):
             self.indices_[cluster_index, :] = performance_indices[
                 diversity_indices]
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """Get the competence estimates of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -253,7 +253,7 @@ class DESClustering(BaseDS):
         competences : array = [n_samples, n_classifiers]
                       The competence level estimated for each base classifier.
         """
-        competences = self.performance_cluster_[neighbors][:]
+        competences = self.performance_cluster_[competence_region][:]
         return competences
 
     def select(self, competences):

--- a/deslib/des/des_clustering.py
+++ b/deslib/des/des_clustering.py
@@ -233,7 +233,7 @@ class DESClustering(BaseDS):
             self.indices_[cluster_index, :] = performance_indices[
                 diversity_indices]
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """Get the competence estimates of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -245,9 +245,6 @@ class DESClustering(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The query sample.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 
@@ -256,7 +253,6 @@ class DESClustering(BaseDS):
         competences : array = [n_samples, n_classifiers]
                       The competence level estimated for each base classifier.
         """
-        # cluster_index = self.clustering_.predict(query)
         competences = self.performance_cluster_[neighbors][:]
         return competences
 
@@ -282,15 +278,12 @@ class DESClustering(BaseDS):
         selected_classifiers = self.indices_[competences, :]
         return selected_classifiers
 
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
         ----------
-        query : array of shape = [n_features]
-                The test sample.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 
@@ -313,20 +306,17 @@ class DESClustering(BaseDS):
         predicted_label : array of shape (n_samples)
                           Predicted class label for each test example.
         """
-        proba = self.predict_proba_with_ds(query, predictions, probabilities,
+        proba = self.predict_proba_with_ds(predictions, probabilities,
                                            neighbors, distances, DFP_mask)
         predicted_label = proba.argmax(axis=1)
         return predicted_label
 
-    def predict_proba_with_ds(self, query, predictions, probabilities,
+    def predict_proba_with_ds(self, predictions, probabilities,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 

--- a/deslib/des/des_clustering.py
+++ b/deslib/des/des_clustering.py
@@ -179,7 +179,7 @@ class DESClustering(BaseDS):
         self._preprocess_clusters()
         return self
 
-    def _get_region_competence(self, query, k=None):
+    def get_region_competence(self, query, k=None):
         distances = self.clustering_.transform(query.astype(np.double))
         region = self.clustering_.predict(query.astype(np.double))
         return distances, region

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -164,7 +164,7 @@ class DESKNN(BaseDS):
         self._set_diversity_func()
         return self
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -179,9 +179,6 @@ class DESKNN(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The query sample.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
@@ -274,15 +271,12 @@ class DESKNN(BaseDS):
 
         return selected_classifiers
 
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples
-
         predictions : array of shape (n_samples, n_classifiers)
                       Predictions of the base classifiers for all test examples
 
@@ -314,20 +308,17 @@ class DESKNN(BaseDS):
         predicted_label : array of shape (n_samples)
                           Predicted class label for each test example.
         """
-        proba = self.predict_proba_with_ds(query, predictions, probabilities,
+        proba = self.predict_proba_with_ds(predictions, probabilities,
                                            neighbors, distances, DFP_mask)
         predicted_label = proba.argmax(axis=1)
         return predicted_label
 
-    def predict_proba_with_ds(self, query, predictions, probabilities,
+    def predict_proba_with_ds(self, predictions, probabilities,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the posterior probabilities.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 
@@ -357,8 +348,7 @@ class DESKNN(BaseDS):
         predicted_proba : array = [n_samples, n_classes]
                           Probability estimates for all test examples.
         """
-        accuracy, diversity = self.estimate_competence(query,
-                                                       neighbors,
+        accuracy, diversity = self.estimate_competence(neighbors,
                                                        distances=distances,
                                                        predictions=predictions)
         if self.DFP:

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -183,8 +183,7 @@ class DESKNN(BaseDS):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+                        Distances from the k nearest neighbors to the query
 
 
         predictions : array of shape (n_samples, n_classifiers)
@@ -288,8 +287,7 @@ class DESKNN(BaseDS):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+                        Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -327,10 +325,10 @@ class DESKNN(BaseDS):
             examples.
 
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -164,7 +164,7 @@ class DESKNN(BaseDS):
         self._set_diversity_func()
         return self
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample.
@@ -179,7 +179,7 @@ class DESKNN(BaseDS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
@@ -208,14 +208,14 @@ class DESKNN(BaseDS):
                     all test examples.
 
         """
-        accuracy = np.mean(self.DSEL_processed_[neighbors, :], axis=1)
+        accuracy = np.mean(self.DSEL_processed_[competence_region, :], axis=1)
 
-        predicted_matrix = self.BKS_DSEL_[neighbors, :]
-        targets = self.DSEL_target_[neighbors]
+        predicted_matrix = self.BKS_DSEL_[competence_region, :]
+        targets = self.DSEL_target_[competence_region]
 
         # TODO: optimize this part with numpy instead of for loops
-        diversity = np.zeros((neighbors.shape[0], self.n_classifiers_))
-        for sample_idx in range(neighbors.shape[0]):
+        diversity = np.zeros((competence_region.shape[0], self.n_classifiers_))
+        for sample_idx in range(competence_region.shape[0]):
             this_diversity = compute_pairwise_diversity(targets[sample_idx, :],
                                                         predicted_matrix[
                                                         sample_idx, :, :],

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -328,7 +328,7 @@ class DESKNN(BaseDS):
             Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.

--- a/deslib/des/des_mi.py
+++ b/deslib/des/des_mi.py
@@ -118,7 +118,7 @@ class DESMI(BaseDS):
         self.pct_accuracy = pct_accuracy
         self.voting = voting
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample. Returns a ndarray
@@ -133,9 +133,6 @@ class DESMI(BaseDS):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The query sample.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
@@ -199,15 +196,12 @@ class DESMI(BaseDS):
 
         return selected_classifiers
 
-    def classify_with_ds(self, query, predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 
@@ -235,21 +229,18 @@ class DESMI(BaseDS):
         predicted_label : array of shape (n_samples)
                           Predicted class label for each test example.
         """
-        proba = self.predict_proba_with_ds(query, predictions, probabilities,
+        proba = self.predict_proba_with_ds(predictions, probabilities,
                                            neighbors, distances, DFP_mask)
         predicted_label = proba.argmax(axis=1)
         return predicted_label
 
-    def predict_proba_with_ds(self, query, predictions, probabilities,
+    def predict_proba_with_ds(self, predictions, probabilities,
                               neighbors=None, distances=None, DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding
         query sample.
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
 
@@ -272,8 +263,7 @@ class DESMI(BaseDS):
         predicted_proba : array = [n_samples, n_classes]
                           Probability estimates for all test examples.
         """
-        accuracy = self.estimate_competence(query,
-                                            neighbors=neighbors,
+        accuracy = self.estimate_competence(neighbors=neighbors,
                                             distances=distances)
 
         if self.DFP:

--- a/deslib/des/des_mi.py
+++ b/deslib/des/des_mi.py
@@ -137,7 +137,7 @@ class DESMI(BaseDS):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/des_mi.py
+++ b/deslib/des/des_mi.py
@@ -118,7 +118,7 @@ class DESMI(BaseDS):
         self.pct_accuracy = pct_accuracy
         self.voting = voting
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence level of each base classifier :math:`c_{i}`
         for the classification of the query sample. Returns a ndarray
@@ -133,7 +133,7 @@ class DESMI(BaseDS):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
@@ -152,12 +152,12 @@ class DESMI(BaseDS):
         """
         # calculate the weight
         class_frequency = np.bincount(self.DSEL_target_)
-        targets = self.DSEL_target_[neighbors]  # [n_samples, K_neighbors]
+        targets = self.DSEL_target_[competence_region]  # [n_samples, K_neighbors]
         num = class_frequency[targets]
         weight = 1. / (1 + np.exp(self.alpha * num))
         weight = normalize(weight, norm='l1')
-        correct_num = self.DSEL_processed_[neighbors, :]
-        correct = np.zeros((neighbors.shape[0], self.k_, self.n_classifiers_))
+        correct_num = self.DSEL_processed_[competence_region, :]
+        correct = np.zeros((competence_region.shape[0], self.k_, self.n_classifiers_))
         for i in range(self.n_classifiers_):
             correct[:, :, i] = correct_num[:, :, i] * weight
 
@@ -263,7 +263,7 @@ class DESMI(BaseDS):
         predicted_proba : array = [n_samples, n_classes]
                           Probability estimates for all test examples.
         """
-        accuracy = self.estimate_competence(neighbors=neighbors,
+        accuracy = self.estimate_competence(competence_region=neighbors,
                                             distances=distances)
 
         if self.DFP:

--- a/deslib/des/des_mi.py
+++ b/deslib/des/des_mi.py
@@ -137,8 +137,7 @@ class DESMI(BaseDS):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+            Distances from the k nearest neighbors to the query
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.
@@ -152,7 +151,7 @@ class DESMI(BaseDS):
         """
         # calculate the weight
         class_frequency = np.bincount(self.DSEL_target_)
-        targets = self.DSEL_target_[competence_region]  # [n_samples, K_neighbors]
+        targets = self.DSEL_target_[competence_region]
         num = class_frequency[targets]
         weight = 1. / (1 + np.exp(self.alpha * num))
         weight = normalize(weight, norm='l1')
@@ -213,8 +212,7 @@ class DESMI(BaseDS):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+                        Distances from the k nearest neighbors to the query
 
         DFP_mask : array of shape (n_samples, n_classifiers)
             Mask containing 1 for the selected base classifier and 0 otherwise.
@@ -235,7 +233,8 @@ class DESMI(BaseDS):
         return predicted_label
 
     def predict_proba_with_ds(self, predictions, probabilities,
-                              neighbors=None, distances=None, DFP_mask=None):
+                              competence_region=None, distances=None,
+                              DFP_mask=None):
         """Predicts the posterior probabilities of the corresponding
         query sample.
 
@@ -248,11 +247,11 @@ class DESMI(BaseDS):
             Probabilities estimates of each base classifier for all test
             examples.
 
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
+            Distances from the k nearest neighbors to each test
             sample.
 
         DFP_mask : array of shape (n_samples, n_classifiers)
@@ -263,8 +262,9 @@ class DESMI(BaseDS):
         predicted_proba : array = [n_samples, n_classes]
                           Probability estimates for all test examples.
         """
-        accuracy = self.estimate_competence(competence_region=neighbors,
-                                            distances=distances)
+        accuracy = self.estimate_competence(
+            competence_region=competence_region,
+            distances=distances)
 
         if self.DFP:
             accuracy = accuracy * DFP_mask

--- a/deslib/des/des_p.py
+++ b/deslib/des/des_p.py
@@ -137,7 +137,7 @@ class DESP(BaseDES):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/des_p.py
+++ b/deslib/des/des_p.py
@@ -123,7 +123,7 @@ class DESP(BaseDES):
                                    n_jobs=n_jobs,
                                    voting=voting)
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample base on its local performance.
@@ -133,7 +133,7 @@ class DESP(BaseDES):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
@@ -149,7 +149,7 @@ class DESP(BaseDES):
             Competence level estimated for each base classifier and test
             example.
         """
-        competences = np.mean(self.DSEL_processed_[neighbors, :], axis=1)
+        competences = np.mean(self.DSEL_processed_[competence_region, :], axis=1)
 
         return competences
 

--- a/deslib/des/des_p.py
+++ b/deslib/des/des_p.py
@@ -123,7 +123,7 @@ class DESP(BaseDES):
                                    n_jobs=n_jobs,
                                    voting=voting)
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}` for
         the classification of the query sample base on its local performance.
@@ -133,9 +133,6 @@ class DESP(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 

--- a/deslib/des/des_p.py
+++ b/deslib/des/des_p.py
@@ -137,8 +137,7 @@ class DESP(BaseDES):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+            Distances from the k nearest neighbors to the query
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/knop.py
+++ b/deslib/des/knop.py
@@ -219,7 +219,7 @@ class KNOP(BaseDES):
                                              return_distance=True)
         return dists, np.atleast_2d(idx)
 
-    def estimate_competence_from_proba(self, query, probabilities,
+    def estimate_competence_from_proba(self, probabilities,
                                        neighbors=None, distances=None):
 
         """The competence of the base classifiers is simply estimated as
@@ -232,9 +232,6 @@ class KNOP(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/des/knop.py
+++ b/deslib/des/knop.py
@@ -234,8 +234,9 @@ class KNOP(BaseDES):
         ----------
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors.
+
         distances : array of shape (n_samples, n_neighbors)
-                        Distances from the k nearest neighbors to the query
+                        Distances from the k nearest neighbors to the query.
 
         probabilities : array of shape (n_samples, n_classifiers, n_classes)
             Probabilities estimates obtained by each each base classifier

--- a/deslib/des/knop.py
+++ b/deslib/des/knop.py
@@ -233,11 +233,9 @@ class KNOP(BaseDES):
         Parameters
         ----------
         neighbors : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+                        Distances from the k nearest neighbors to the query
 
         probabilities : array of shape (n_samples, n_classifiers, n_classes)
             Probabilities estimates obtained by each each base classifier

--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -121,7 +121,7 @@ class KNORAE(BaseDES):
                                      voting=voting,
                                      )
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """ Estimate the competence of the base classifiers. In the case of
         the KNORA-E technique, the classifiers are only considered competent
@@ -133,7 +133,7 @@ class KNORAE(BaseDES):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -149,7 +149,7 @@ class KNORAE(BaseDES):
             Competence level estimated for each base classifier and test
             example.
         """
-        results_neighbors = self.DSEL_processed_[neighbors, :]
+        results_neighbors = self.DSEL_processed_[competence_region, :]
 
         # Get the shape of the vector in order to know the number of samples,
         # base classifiers and neighbors considered.

--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -121,9 +121,9 @@ class KNORAE(BaseDES):
                                      voting=voting,
                                      )
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
-        """Estimate the competence of the base classifiers. In the case of
+        """ Estimate the competence of the base classifiers. In the case of
         the KNORA-E technique, the classifiers are only considered competent
         when they achieve a 100% accuracy in the region of competence.
         For each base, we estimate the maximum size of the region of competence
@@ -133,9 +133,6 @@ class KNORAE(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -137,7 +137,7 @@ class KNORAE(BaseDES):
             Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -134,11 +134,10 @@ class KNORAE(BaseDES):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
+            Indices of the k nearest neighbors.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+            Distances from the k nearest neighbors to the query
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/knora_u.py
+++ b/deslib/des/knora_u.py
@@ -127,10 +127,9 @@ class KNORAU(BaseDES):
         Parameters
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
-            Indices of the k nearest neighbors according for each test sample
-
+            Indices of the k nearest neighbors.
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test sample
+            Distances from the k nearest neighbors to the query
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/knora_u.py
+++ b/deslib/des/knora_u.py
@@ -115,7 +115,7 @@ class KNORAU(BaseDES):
                                      n_jobs=n_jobs,
                                      voting=voting)
 
-    def estimate_competence(self, neighbors, distances=None,
+    def estimate_competence(self, competence_region, distances=None,
                             predictions=None):
         """The competence of the base classifiers is simply estimated as the
         number of samples in the region of competence that it
@@ -126,7 +126,7 @@ class KNORAU(BaseDES):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 
         distances : array of shape (n_samples, n_neighbors)
@@ -142,7 +142,7 @@ class KNORAU(BaseDES):
             example.
 
         """
-        competences = np.sum(self.DSEL_processed_[neighbors, :], axis=1,
+        competences = np.sum(self.DSEL_processed_[competence_region, :], axis=1,
                              dtype=np.float)
 
         return competences

--- a/deslib/des/knora_u.py
+++ b/deslib/des/knora_u.py
@@ -128,8 +128,9 @@ class KNORAU(BaseDES):
         ----------
         competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors.
+
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/knora_u.py
+++ b/deslib/des/knora_u.py
@@ -115,7 +115,7 @@ class KNORAU(BaseDES):
                                      n_jobs=n_jobs,
                                      voting=voting)
 
-    def estimate_competence(self, query, neighbors, distances=None,
+    def estimate_competence(self, neighbors, distances=None,
                             predictions=None):
         """The competence of the base classifiers is simply estimated as the
         number of samples in the region of competence that it
@@ -126,9 +126,6 @@ class KNORAU(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample
 

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -338,7 +338,7 @@ class METADES(BaseDES):
         # Get the region of competence using the feature space and
         # the decision space. Use K + 1 to later remove itself
         # from the set.
-        _, idx_neighbors = self.get_region_competence(
+        _, idx_neighbors = self.get_competence_region(
             self.DSEL_data_[indices_selected, :], self.k_ + 1)
         _, idx_neighbors_op = self._get_similar_out_profiles(
             self.dsel_scores_[indices_selected], self.Kp_ + 1)

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -461,7 +461,7 @@ class METADES(BaseDES):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances from the k nearest neighbors to the query
+            Distances from the k nearest neighbors to the query.
 
         probabilities : array of shape (n_samples, n_classifiers, n_classes)
             Probabilities estimates obtained by each each base classifier for

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -444,7 +444,7 @@ class METADES(BaseDES):
 
         return selected_classifiers
 
-    def estimate_competence_from_proba(self, query, neighbors, probabilities,
+    def estimate_competence_from_proba(self, neighbors, probabilities,
                                        distances=None):
         """Estimate the competence of each base classifier :math:`c_i`
         the classification of the query sample. This method received an array
@@ -457,9 +457,6 @@ class METADES(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -338,7 +338,7 @@ class METADES(BaseDES):
         # Get the region of competence using the feature space and
         # the decision space. Use K + 1 to later remove itself
         # from the set.
-        _, idx_neighbors = self._get_region_competence(
+        _, idx_neighbors = self.get_region_competence(
             self.DSEL_data_[indices_selected, :], self.k_ + 1)
         _, idx_neighbors_op = self._get_similar_out_profiles(
             self.dsel_scores_[indices_selected], self.Kp_ + 1)

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -461,8 +461,7 @@ class METADES(BaseDES):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+            Distances from the k nearest neighbors to the query
 
         probabilities : array of shape (n_samples, n_classifiers, n_classes)
             Probabilities estimates obtained by each each base classifier for

--- a/deslib/des/probabilistic/base.py
+++ b/deslib/des/probabilistic/base.py
@@ -108,8 +108,7 @@ class BaseProbabilistic(BaseDES):
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
-            Distances of the k nearest neighbors according for each test
-            sample.
+            Distances from the k nearest neighbors to the query.
 
         predictions : array of shape (n_samples, n_classifiers)
             Predictions of the base classifiers for all test examples.

--- a/deslib/des/probabilistic/base.py
+++ b/deslib/des/probabilistic/base.py
@@ -92,7 +92,7 @@ class BaseProbabilistic(BaseDES):
             )
         super(BaseProbabilistic, self)._validate_parameters()
 
-    def estimate_competence(self, neighbors, distances, predictions=None):
+    def estimate_competence(self, competence_region, distances, predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}`
         using the source of competence :math:`C_{src}` and the potential
         function model. The source of competence :math:`C_{src}` for all
@@ -104,7 +104,7 @@ class BaseProbabilistic(BaseDES):
 
         Parameters
         ----------
-        neighbors : array of shape (n_samples, n_neighbors)
+        competence_region : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 
         distances : array of shape (n_samples, n_neighbors)
@@ -124,7 +124,7 @@ class BaseProbabilistic(BaseDES):
         potential_dists[potential_dists == 0] = 1e-20
         sum_potential = np.sum(potential_dists, axis=1)
 
-        competences = np.einsum('ijk,ij->ik', self.C_src_[neighbors, :],
+        competences = np.einsum('ijk,ij->ik', self.C_src_[competence_region, :],
                                 potential_dists)
         competences = competences / sum_potential.reshape(-1, 1)
 

--- a/deslib/des/probabilistic/base.py
+++ b/deslib/des/probabilistic/base.py
@@ -92,11 +92,7 @@ class BaseProbabilistic(BaseDES):
             )
         super(BaseProbabilistic, self)._validate_parameters()
 
-    def estimate_competence(self,
-                            query,
-                            neighbors,
-                            distances,
-                            predictions=None):
+    def estimate_competence(self, neighbors, distances, predictions=None):
         """estimate the competence of each base classifier :math:`c_{i}`
         using the source of competence :math:`C_{src}` and the potential
         function model. The source of competence :math:`C_{src}` for all
@@ -108,9 +104,6 @@ class BaseProbabilistic(BaseDES):
 
         Parameters
         ----------
-        query : array of shape (n_samples, n_features)
-                The test examples.
-
         neighbors : array of shape (n_samples, n_neighbors)
             Indices of the k nearest neighbors according for each test sample.
 

--- a/deslib/tests/dcs/test_a_posteriori.py
+++ b/deslib/tests/dcs/test_a_posteriori.py
@@ -1,6 +1,7 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
-from unittest.mock import MagicMock
 from sklearn.linear_model import Perceptron
 from sklearn.utils.estimator_checks import check_estimator
 
@@ -30,7 +31,7 @@ def test_estimate_competence_all_ones(index, example_all_ones):
     expected = [1.0, 1.0, 1.0]
     predictions = np.array([0, 1, 0])
 
-    competences = a_posteriori_test.estimate_competence(query, neighbors,
+    competences = a_posteriori_test.estimate_competence(neighbors,
                                                         distances,
                                                         predictions=np.array(
                                                             predictions))
@@ -54,7 +55,7 @@ def test_estimate_competence_kuncheva_ex(example_kuncheva):
 
     predictions = np.array([[1]])
 
-    competences = a_posteriori_test.estimate_competence(query, neighbors,
+    competences = a_posteriori_test.estimate_competence(neighbors,
                                                         distances,
                                                         predictions=np.array(
                                                             predictions))
@@ -83,7 +84,7 @@ def test_estimate_competence_kuncheva_ex_batch(example_kuncheva):
     distances = example_kuncheva['distances']
 
     predictions = [1]
-    competences = a_posteriori_test.estimate_competence(query, neighbors,
+    competences = a_posteriori_test.estimate_competence(neighbors,
                                                         distances,
                                                         predictions=np.array(
                                                             predictions))
@@ -111,7 +112,7 @@ def test_estimate_competence_diff_target(index, example_all_ones):
     expected = [0.0, 0.0, 0.0]
 
     predictions = np.array([0, 1, 0])
-    competences = a_posteriori_test.estimate_competence(query, neighbors,
+    competences = a_posteriori_test.estimate_competence(neighbors,
                                                         distances,
                                                         predictions=np.array(
                                                             predictions))

--- a/deslib/tests/dcs/test_a_priori.py
+++ b/deslib/tests/dcs/test_a_priori.py
@@ -16,7 +16,6 @@ def test_check_estimator():
                                              (2, [1.0, 1.0, 1.0])])
 def test_estimate_competence_all_ones(index, expected, example_all_ones):
     X, y, neighbors, distances, dsel_processed, dsel_scores = example_all_ones
-    query = np.array([1, 1])
 
     a_priori_test = APriori()
 
@@ -28,14 +27,12 @@ def test_estimate_competence_all_ones(index, expected, example_all_ones):
     neighbors = neighbors[index, :].reshape(1, -1)
     distances = distances[index, :].reshape(1, -1)
 
-    competences = a_priori_test.estimate_competence(query.reshape(1, -1),
-                                                    neighbors, distances)
+    competences = a_priori_test.estimate_competence(neighbors, distances)
     assert np.isclose(competences, expected).all()
 
 
 # Testing example from kuncheva's book (combining pattern classifiers)
 def test_estimate_competence_kuncheva_ex(example_kuncheva):
-    query = np.array([1, 1])
     a_priori_test = APriori(k=example_kuncheva['k'])
     test_example = example_kuncheva
     a_priori_test.DSEL_processed_ = test_example['dsel_processed']
@@ -46,16 +43,13 @@ def test_estimate_competence_kuncheva_ex(example_kuncheva):
     neighbors = test_example['neighbors'].reshape(1, -1)
     distances = test_example['distances'].reshape(1, -1)
 
-    competences = a_priori_test.estimate_competence(query.reshape(1, -1),
-                                                    neighbors, distances)
+    competences = a_priori_test.estimate_competence(neighbors, distances)
     assert np.isclose(competences, 0.70, atol=0.01)
 
 
 # Test the estimate competence method receiving n samples as input
 def test_estimate_competence_batch(example_estimate_competence):
     _, y, nn, _, dsel_processed, dsel_scores = example_estimate_competence
-
-    query = np.ones((3, 2))
     expected = np.array([[0.333333, 0.50000, 0.40000],
                          [0.666666, 0.50000, 0.60000],
                          [0.000000, 0.50000, 0.20000]])
@@ -71,7 +65,7 @@ def test_estimate_competence_batch(example_estimate_competence):
     nn = nn[:, 0:3]
     distances = np.ones((3, 3))
 
-    competences = a_priori_test.estimate_competence(query, nn,
+    competences = a_priori_test.estimate_competence(nn,
                                                     distances)
     assert np.allclose(competences, expected, atol=0.01)
 

--- a/deslib/tests/dcs/test_base.py
+++ b/deslib/tests/dcs/test_base.py
@@ -153,7 +153,7 @@ def test_classify_instance(create_pool_classifiers):
     predictions = []
     for clf in dcs_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
-    predicted_label = dcs_test.classify_with_ds(query, np.array(predictions))
+    predicted_label = dcs_test.classify_with_ds(np.array(predictions))
     assert predicted_label == expected
 
 
@@ -175,8 +175,7 @@ def test_classify_instance_batch(create_pool_classifiers):
     predictions = []
     for clf in dcs_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
-    predicted_label = dcs_test.classify_with_ds(query,
-                                                np.tile(predictions, (3, 1)))
+    predicted_label = dcs_test.classify_with_ds(np.tile(predictions, (3, 1)))
     assert np.array_equal(predicted_label, expected)
 
 
@@ -192,7 +191,7 @@ def test_classify_instance_all(competences, expected, create_pool_classifiers):
     predictions = []
     for clf in dcs_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
-    predicted_label = dcs_test.classify_with_ds(query, np.array(predictions))
+    predicted_label = dcs_test.classify_with_ds(np.array(predictions))
     assert predicted_label == expected
 
 
@@ -209,8 +208,8 @@ def test_classify_instance_all_batch(create_pool_classifiers):
     predictions = []
     for clf in dcs_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
-    predicted_label = dcs_test.classify_with_ds(query, np.tile(predictions,
-                                                               (n_samples, 1)))
+    predicted_label = dcs_test.classify_with_ds(np.tile(predictions,
+                                                        (n_samples, 1)))
     assert np.array_equal(predicted_label, expected)
 
 
@@ -237,7 +236,7 @@ def test_predict_proba_instance(create_pool_classifiers):
     probabilities = np.array(probabilities)
     probabilities = np.expand_dims(probabilities, axis=0)
 
-    predicted_proba = dcs_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = dcs_test.predict_proba_with_ds(predictions,
                                                      probabilities)
     assert np.array_equal(predicted_proba, expected)
 
@@ -261,11 +260,10 @@ def test_predict_proba_instance_all(competences, expected,
         predictions.append(clf.predict(query)[0])
         probabilities.append(clf.predict_proba(query)[0])
 
-    query = np.atleast_2d(query)
     predictions = np.atleast_2d(predictions)
     probabilities = np.array(probabilities)
     probabilities = np.expand_dims(probabilities, axis=0)
 
-    predicted_proba = dcs_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = dcs_test.predict_proba_with_ds(predictions,
                                                      probabilities)
     assert np.isclose(predicted_proba, expected).all()

--- a/deslib/tests/dcs/test_lca.py
+++ b/deslib/tests/dcs/test_lca.py
@@ -23,7 +23,7 @@ def test_estimate_competence_batch(example_estimate_competence):
     query = np.ones((3, 2))
 
     predictions = np.array([[0, 1, 0]])
-    competences = lca_test.estimate_competence(query, neighbors,
+    competences = lca_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=np.array(
                                                    predictions))
@@ -50,8 +50,7 @@ def test_estimate_competence_diff_target(index,
     expected = [0.0, 0.0, 0.0]
 
     predictions = np.array([[0, 1, 0]])
-    competences = lca_test.estimate_competence(query,
-                                               neighbors,
+    competences = lca_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=np.array(
                                                    predictions))

--- a/deslib/tests/dcs/test_mcb.py
+++ b/deslib/tests/dcs/test_mcb.py
@@ -46,7 +46,6 @@ def test_similarity_threshold_type(similarity_threshold, create_X_y):
 def test_estimate_competence2(index, expected, example_estimate_competence):
 
     _, _, neighbors, distances, dsel_processed, _ = example_estimate_competence
-    query = np.ones((1, 2))
 
     mcb_test = MCB()
     mcb_test.n_classifiers_ = 3
@@ -59,8 +58,7 @@ def test_estimate_competence2(index, expected, example_estimate_competence):
 
     predictions = np.array([[0, 1, 0]])
 
-    competences = mcb_test.estimate_competence(query,
-                                               neighbors,
+    competences = mcb_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=np.atleast_2d(
                                                    predictions))
@@ -73,7 +71,6 @@ def test_estimate_competence2(index, expected, example_estimate_competence):
 def test_estimate_competence_batch(example_estimate_competence):
     _, _, neighbors, distances, dsel_processed, _ = example_estimate_competence
 
-    query = np.ones((3, 2))
     expected = np.array([[0.57142857, 0.71428571, 0.71428571],
                          [0.71428571, 0.85714286, 0.71428571],
                          [0.57142857, 0.71428571, 0.57142857]])
@@ -86,8 +83,7 @@ def test_estimate_competence_batch(example_estimate_competence):
 
     predictions = np.array([0, 1, 0])
 
-    competences = mcb_test.estimate_competence(query,
-                                               neighbors,
+    competences = mcb_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=np.tile(predictions,
                                                                    (3, 1)))

--- a/deslib/tests/dcs/test_mla.py
+++ b/deslib/tests/dcs/test_mla.py
@@ -14,7 +14,6 @@ def test_check_estimator():
 @pytest.mark.parametrize('index', [0, 1, 2])
 def test_estimate_competence_all_ones(index, example_all_ones):
     _, y, neighbors, distances, dsel_processed, dsel_scores = example_all_ones
-    query = np.atleast_2d([1, 1])
 
     mla_test = MLA()
     mla_test.n_classifiers_ = 3
@@ -31,8 +30,7 @@ def test_estimate_competence_all_ones(index, example_all_ones):
 
     predictions = np.array([[0, 1, 0]])
 
-    competences = mla_test.estimate_competence(query,
-                                               neighbors,
+    competences = mla_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=predictions)
 
@@ -43,7 +41,6 @@ def test_estimate_competence_batch(example_estimate_competence):
 
     _, y, neighbors, _, dsel_processed, _ = example_estimate_competence
 
-    query = np.array([[1, 1], [1, 1], [1, 1]])
     expected = np.array([[0.750,  0.666,  0.750],
                          [0.800,  1.000,  0.800],
                          [1.000,  0.600,  0.500]])
@@ -57,8 +54,7 @@ def test_estimate_competence_batch(example_estimate_competence):
     mla_test.n_classes_ = 2
     predictions = np.array([[0, 1, 0]])
 
-    competences = mla_test.estimate_competence(query,
-                                               neighbors=neighbors,
+    competences = mla_test.estimate_competence(competence_region=neighbors,
                                                distances=distances,
                                                predictions=predictions)
 
@@ -70,8 +66,6 @@ def test_estimate_competence_batch(example_estimate_competence):
 @pytest.mark.parametrize('index', [0, 1, 2])
 def test_estimate_competence_diff_target(index, example_estimate_competence):
     _, _, neighbors, distances, dsel_processed, _ = example_estimate_competence
-
-    query = np.atleast_2d([1, 1])
 
     mla_test = MLA()
     mla_test.n_classifiers_ = 3
@@ -86,8 +80,7 @@ def test_estimate_competence_diff_target(index, example_estimate_competence):
 
     predictions = np.array([[0, 1, 0]])
 
-    competences = mla_test.estimate_competence(query,
-                                               neighbors,
+    competences = mla_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=predictions)
 
@@ -96,7 +89,6 @@ def test_estimate_competence_diff_target(index, example_estimate_competence):
 
 # Testing example from kuncheva's book (combining pattern classifiers)
 def test_estimate_competence_kuncheva_ex(example_kuncheva):
-    query = np.atleast_2d([1, 1])
     example_kuncheva = example_kuncheva
 
     mla_test = MLA(k=example_kuncheva['k'])
@@ -114,8 +106,7 @@ def test_estimate_competence_kuncheva_ex(example_kuncheva):
     distances = example_kuncheva['distances'].reshape(1, -1)
 
     predictions = np.array([[1, 1]])
-    competences = mla_test.estimate_competence(query,
-                                               neighbors,
+    competences = mla_test.estimate_competence(neighbors,
                                                distances=distances,
                                                predictions=predictions)
 

--- a/deslib/tests/dcs/test_ola.py
+++ b/deslib/tests/dcs/test_ola.py
@@ -19,8 +19,7 @@ def test_estimate_competence_batch(example_estimate_competence):
     ola_test.DSEL_processed_ = dsel_processed
 
     ola_test.DFP_mask = np.ones((3, 3))
-    query = np.array([[1, 1], [1, 1], [1, 1]])
-    competences = ola_test.estimate_competence(query, neighbors,
+    competences = ola_test.estimate_competence(neighbors,
                                                distances=distances)
     assert np.allclose(competences, expected)
 

--- a/deslib/tests/dcs/test_rank.py
+++ b/deslib/tests/dcs/test_rank.py
@@ -17,8 +17,7 @@ def test_estimate_competence_batch(example_estimate_competence):
                          [0, 0, 1]])
     rank_test = Rank()
     rank_test.DSEL_processed_ = dsel_processed
-    query = np.array([[1, 1], [1, 1], [1, 1]])
-    competences = rank_test.estimate_competence(query, neighbors,
+    competences = rank_test.estimate_competence(neighbors,
                                                 distances=distances)
     assert np.allclose(competences, expected)
 

--- a/deslib/tests/des/test_base.py
+++ b/deslib/tests/des/test_base.py
@@ -48,8 +48,8 @@ def test_classify_instance_selection(create_pool_classifiers):
     for clf in des_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
 
-    predicted_label = des_test.classify_with_ds(query, np.tile(predictions,
-                                                               (n_samples, 1)))
+    predicted_label = des_test.classify_with_ds(np.tile(predictions,
+                                                        (n_samples, 1)))
     assert np.allclose(predicted_label, 0) and predicted_label.size == 3
 
 
@@ -67,8 +67,7 @@ def test_classify_instance_weighting(create_pool_classifiers):
     predictions = []
     for clf in des_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
-    predicted_label = des_test.classify_with_ds(query,
-                                                np.tile(predictions, (3, 1)))
+    predicted_label = des_test.classify_with_ds(np.tile(predictions, (3, 1)))
     assert np.allclose(predicted_label, 1) and predicted_label.size == 3
 
 
@@ -92,8 +91,7 @@ def test_classify_instance_hybrid(create_pool_classifiers):
     for clf in des_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
 
-    predicted_label = des_test.classify_with_ds(query,
-                                                np.tile(predictions, (3, 1)))
+    predicted_label = des_test.classify_with_ds(np.tile(predictions, (3, 1)))
     assert np.allclose(predicted_label, expected)
 
 
@@ -113,7 +111,7 @@ def test_predict_proba_selection_soft_voting(create_pool_classifiers):
     des_test.select = MagicMock(return_value=selected_indices)
     des_test.n_classes_ = 2
 
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = des_test.predict_proba_with_ds(predictions,
                                                      probabilities)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
@@ -132,7 +130,7 @@ def test_predict_proba_weighting_soft_voting(create_pool_classifiers):
     des_test.estimate_competence = MagicMock(return_value=competences)
     des_test.n_classes_ = 2
 
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = des_test.predict_proba_with_ds(predictions,
                                                      probabilities)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
@@ -153,7 +151,7 @@ def test_predict_proba_hybrid_soft_voting(create_pool_classifiers):
     des_test.n_classes_ = 2
     des_test.estimate_competence = MagicMock(return_value=competences)
     des_test.select = MagicMock(return_value=selected_indices)
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = des_test.predict_proba_with_ds(predictions,
                                                      probabilities)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
@@ -170,7 +168,7 @@ def test_predict_proba_selection_hard_voting(create_pool_classifiers):
     des_test.n_classes_ = 2
     des_test.select = MagicMock(return_value=selected_indices)
 
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions)
+    predicted_proba = des_test.predict_proba_with_ds(predictions)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
 
@@ -187,7 +185,7 @@ def test_predict_proba_weighting_hard_voting(create_pool_classifiers):
     des_test.estimate_competence = MagicMock(return_value=competences)
     des_test.n_classes_ = 2
 
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions)
+    predicted_proba = des_test.predict_proba_with_ds(predictions)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
 
@@ -206,7 +204,7 @@ def test_predict_proba_hybrid_hard_voting(create_pool_classifiers):
     des_test.estimate_competence = MagicMock(return_value=competences)
     des_test.select = MagicMock(return_value=selected_indices)
 
-    predicted_proba = des_test.predict_proba_with_ds(query, predictions)
+    predicted_proba = des_test.predict_proba_with_ds(predictions)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
 

--- a/deslib/tests/des/test_des_clustering.py
+++ b/deslib/tests/des/test_des_clustering.py
@@ -71,19 +71,18 @@ def test_fit_heterogeneous_clusters(example_estimate_competence,
 
 def test_estimate_competence(create_pool_classifiers,
                              example_estimate_competence):
-    query = np.atleast_2d([1, 1])
     clustering_test = DESClustering(create_pool_classifiers * 2,
                                     clustering=KMeans(n_clusters=2),
                                     pct_accuracy=0.5, pct_diversity=0.33)
 
     X, y = example_estimate_competence[0:2]
     clustering_test.fit(X, y)
-    competences = clustering_test.estimate_competence(query, 0)
+    competences = clustering_test.estimate_competence(0)
 
     assert np.array_equal(competences,
                           clustering_test.performance_cluster_[0, :])
 
-    competences = clustering_test.estimate_competence(query, 1)
+    competences = clustering_test.estimate_competence(1)
     assert np.array_equal(competences,
                           clustering_test.performance_cluster_[1, :])
 
@@ -130,8 +129,7 @@ def test_classify_instance(create_pool_classifiers):
     for clf in clustering_test.pool_classifiers:
         predictions.append(clf.predict(query)[0])
 
-    predicted = clustering_test.classify_with_ds(query,
-                                                 np.atleast_2d(predictions))
+    predicted = clustering_test.classify_with_ds(np.atleast_2d(predictions))
     assert predicted == 0
 
 

--- a/deslib/tests/des/test_des_knn.py
+++ b/deslib/tests/des/test_des_knn.py
@@ -33,7 +33,6 @@ def test_estimate_competence():
     clf3 diversity = (2+1)/7 = -3/7
 
     """
-    query = np.ones((1, 2))
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -46,7 +45,7 @@ def test_estimate_competence():
     target = DESKNN(pool_classifiers, k=7, pct_accuracy=1, pct_diversity=1)
     target.fit(x, y)
     neighbors = np.array([[0, 1, 2, 3, 4, 5, 6]])
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [-5. / 7, -4. / 7, -3. / 7])
 
@@ -74,7 +73,6 @@ def test_estimate_competence_batch():
     """
 
     n_samples = 10
-    query = np.ones((n_samples, 2))
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -88,13 +86,12 @@ def test_estimate_competence_batch():
     target.fit(x, y)
     neighbors = np.tile([0, 1, 2, 3, 4, 5, 6], (10, 1))
 
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [-5. / 7, -4. / 7, -3. / 7])
 
 
 def test_estimate_competence_Q():
-    query = np.ones((1, 2))
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -109,14 +106,13 @@ def test_estimate_competence_Q():
     target.fit(x, y)
     neighbors = np.array([[0, 1, 2, 3, 4, 5, 6]])
 
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [2, 1.2, 1.2])
 
 
 def test_estimate_competence_Q_batch():
     n_samples = 10
-    query = np.ones((n_samples, 2))
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -131,14 +127,12 @@ def test_estimate_competence_Q_batch():
     target.fit(x, y)
     neighbors = np.tile([0, 1, 2, 3, 4, 5, 6], (n_samples, 1))
 
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [2, 1.2, 1.2])
 
 
 def test_estimate_competence_ratio():
-    query = np.ones((1, 2))
-
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -153,15 +147,13 @@ def test_estimate_competence_ratio():
     target.fit(x, y)
     neighbors = np.array([[0, 1, 2, 3, 4, 5, 6]])
 
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [2.166, 3.666, 4.500], atol=0.01)
 
 
 def test_estimate_competence_ratio_batch():
     n_samples = 10
-    query = np.ones((n_samples, 2))
-
     x = np.array([0, 1, 2, 3, 4, 5, 6]).reshape(-1, 1)
     y = np.array([0, 0, 0, 0, 1, 1, 1])
 
@@ -176,7 +168,7 @@ def test_estimate_competence_ratio_batch():
     target.fit(x, y)
     neighbors = np.tile([0, 1, 2, 3, 4, 5, 6], (n_samples, 1))
 
-    competences, diversity = target.estimate_competence(query, neighbors)
+    competences, diversity = target.estimate_competence(neighbors)
     assert np.allclose(competences, [2. / 7, 4. / 7, 5. / 7])
     assert np.allclose(diversity, [2.166, 3.666, 4.500], atol=0.01)
 

--- a/deslib/tests/des/test_des_mi.py
+++ b/deslib/tests/des/test_des_mi.py
@@ -72,8 +72,6 @@ def test_select_batch_samples():
 
 def test_classify_with_ds_batch_samples():
     n_samples = 10
-    # Passing 10 samples for classification automatically
-    query = np.ones((n_samples, 2))
 
     # simulated predictions of the pool of classifiers
     predictions = np.tile(np.array([0, 1, 0]), (n_samples, 1))
@@ -84,12 +82,11 @@ def test_classify_with_ds_batch_samples():
         return_value=(np.ones((n_samples, 3))))
     desmi_test.select = MagicMock(
         return_value=np.tile(np.array([[0, 2]]), (n_samples, 1)))
-    result = desmi_test.classify_with_ds(query, predictions)
+    result = desmi_test.classify_with_ds(predictions)
     assert np.allclose(result, np.zeros(10))
 
 
 def test_predict_proba_with_ds_soft(create_pool_classifiers):
-    query = np.array([-1, 1])
     expected = np.array([0.61, 0.39])
     DFP_mask = np.ones((1, 6))
     predictions = np.array([[0, 1, 0, 0, 1, 0]])
@@ -102,14 +99,13 @@ def test_predict_proba_with_ds_soft(create_pool_classifiers):
     desmi_test.estimate_competence = MagicMock(return_value=np.ones(6))
     desmi_test.select = MagicMock(return_value=selected_indices)
 
-    predicted_proba = desmi_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = desmi_test.predict_proba_with_ds(predictions,
                                                        probabilities,
                                                        DFP_mask=DFP_mask)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()
 
 
 def test_predict_proba_with_ds_hard(create_pool_classifiers):
-    query = np.array([-1, 1])
     expected = np.array([0.666, 0.333])
     DFP_mask = np.ones((1, 6))
     predictions = np.array([[0, 1, 0, 0, 1, 0]])
@@ -122,7 +118,7 @@ def test_predict_proba_with_ds_hard(create_pool_classifiers):
     desmi_test.estimate_competence = MagicMock(return_value=np.ones(6))
     desmi_test.select = MagicMock(return_value=selected_indices)
 
-    predicted_proba = desmi_test.predict_proba_with_ds(query, predictions,
+    predicted_proba = desmi_test.predict_proba_with_ds(predictions,
                                                        probabilities,
                                                        DFP_mask=DFP_mask)
     assert np.isclose(predicted_proba, expected, atol=0.01).all()

--- a/deslib/tests/des/test_desp.py
+++ b/deslib/tests/des/test_desp.py
@@ -12,7 +12,6 @@ def test_check_estimator():
 # Test the estimate competence method receiving n samples as input
 def test_estimate_competence_batch(example_estimate_competence,
                                    create_pool_classifiers):
-    query = np.ones((3, 2))
     X, y, neighbors, distances, dsel_processed, _ = example_estimate_competence
 
     expected = np.array([[0.57142857, 0.4285714, 0.57142857],
@@ -21,7 +20,7 @@ def test_estimate_competence_batch(example_estimate_competence,
 
     des_p_test = DESP(create_pool_classifiers)
     des_p_test.fit(X, y)
-    competences = des_p_test.estimate_competence(query, neighbors, distances)
+    competences = des_p_test.estimate_competence(neighbors, distances)
     assert np.allclose(competences, expected, atol=0.01)
 
 

--- a/deslib/tests/des/test_knorae.py
+++ b/deslib/tests/des/test_knorae.py
@@ -14,7 +14,6 @@ def test_estimate_competence_batch(example_estimate_competence,
                                    create_pool_classifiers):
     X, y, neighbors, distances, _, _ = example_estimate_competence
 
-    query = np.ones((3, 2))
     expected = np.array([[1.0, 0.0, 1.0],
                          [2.0, 0.0, 2.0],
                          [0.0, 3.0, 0.0]])
@@ -22,7 +21,7 @@ def test_estimate_competence_batch(example_estimate_competence,
     knora_e_test = KNORAE(create_pool_classifiers)
     knora_e_test.fit(X, y)
 
-    competences = knora_e_test.estimate_competence(query, neighbors,
+    competences = knora_e_test.estimate_competence(neighbors,
                                                    distances=distances)
     assert np.allclose(competences, expected)
 
@@ -34,14 +33,11 @@ def test_select(index, expected, create_pool_classifiers,
                 example_estimate_competence):
     X, y, neighbors, distances, _, _ = example_estimate_competence
 
-    query = np.atleast_2d([1, 1])
-
     knora_e_test = KNORAE(create_pool_classifiers)
     knora_e_test.fit(X, y)
     neighbors = neighbors[index, :].reshape(1, -1)
     distances = distances[index, :].reshape(1, -1)
-    competences = knora_e_test.estimate_competence(query,
-                                                   neighbors,
+    competences = knora_e_test.estimate_competence(neighbors,
                                                    distances=distances)
     selected = knora_e_test.select(competences)
 

--- a/deslib/tests/des/test_knorau.py
+++ b/deslib/tests/des/test_knorau.py
@@ -15,14 +15,13 @@ def test_estimate_competence_batch(example_estimate_competence,
 
     X, y, neighbors = example_estimate_competence[0:3]
 
-    query = np.ones((3, 2))
     expected = np.array([[4.0, 3.0, 4.0],
                          [5.0, 2.0, 5.0],
                          [2.0, 5.0, 2.0]])
     knora_u_test = KNORAU(create_pool_classifiers)
     knora_u_test.fit(X, y)
 
-    competences = knora_u_test.estimate_competence(query, neighbors)
+    competences = knora_u_test.estimate_competence(neighbors)
     assert np.allclose(competences, expected, atol=0.01)
 
 

--- a/deslib/tests/des/test_meta_des.py
+++ b/deslib/tests/des/test_meta_des.py
@@ -144,8 +144,7 @@ def test_estimate_competence(example_estimate_competence,
     probabilities = np.array(probabilities).transpose((1, 0, 2))
 
     expected = np.array([[0.8, 0.0, 0.8]])
-    competences = meta_test.estimate_competence_from_proba(query,
-                                                           nn[0, :],
+    competences = meta_test.estimate_competence_from_proba(nn[0, :],
                                                            probabilities)
     assert np.array_equal(competences, expected)
 

--- a/deslib/tests/des/test_probabilistic.py
+++ b/deslib/tests/des/test_probabilistic.py
@@ -122,9 +122,9 @@ def test_estimate_competence_batch():
     probabilistic_test.C_src_ = np.array(
         [[0.5, 0.2, 0.8], [1.0, 1.0, 1.0], [1.0, 0.6, 0.3]])
     expected = np.tile([0.665, 0.458, 0.855], (n_samples, 1))
-    competence = probabilistic_test.estimate_competence(query,
-                                                        neighbors=neighbors,
-                                                        distances=distances)
+    competence = probabilistic_test.estimate_competence(
+        competence_region=neighbors,
+        distances=distances)
     assert np.allclose(competence, expected, atol=0.01)
 
 
@@ -139,9 +139,9 @@ def test_estimate_competence_zeros(example_estimate_competence):
     distances = distances[0, 0:3].reshape(1, -1)
     neighbors = np.array([[0, 2, 1]])
     probabilistic_test.C_src_ = np.zeros((3, 3))
-    competence = probabilistic_test.estimate_competence(query,
-                                                        neighbors=neighbors,
-                                                        distances=distances)
+    competence = probabilistic_test.estimate_competence(
+        competence_region=neighbors,
+        distances=distances)
     assert np.sum(competence) == 0.0
 
 
@@ -156,7 +156,7 @@ def test_estimate_competence_ones(example_estimate_competence):
     distances = distances[0, 0:3].reshape(1, -1)
     neighbors = np.array([[0, 2, 1]])
     probabilistic_test.C_src_ = np.ones((3, 3))
-    competence = probabilistic_test.estimate_competence(query, neighbors,
+    competence = probabilistic_test.estimate_competence(neighbors,
                                                         distances)
     assert (competence == 1.0).all()
 

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -195,7 +195,7 @@ def test_IH_is_used(example_estimate_competence, create_pool_classifiers):
 
     ds_test.DSEL_processed_ = dsel_processed
 
-    ds_test.get_region_competence = MagicMock(return_value=(distances,
+    ds_test.get_competence_region = MagicMock(return_value=(distances,
                                                             neighbors))
     predicted = ds_test.predict(query)
 
@@ -239,7 +239,7 @@ def test_predict_proba_IH_knn(index,
     neighbors = neighbors[index, :]
     distances = distances[index, :]
 
-    ds_test.get_region_competence = MagicMock(return_value=(distances,
+    ds_test.get_competence_region = MagicMock(return_value=(distances,
                                                             neighbors))
 
     ds_test.roc_algorithm_.predict_proba = MagicMock(
@@ -263,7 +263,7 @@ def test_predict_proba_instance_called(index,
     neighbors = neighbors[index, :]
     distances = distances[index, :]
 
-    ds_test.get_region_competence = MagicMock(return_value=(distances,
+    ds_test.get_competence_region = MagicMock(return_value=(distances,
                                                             neighbors))
 
     ds_test.predict_proba_with_ds = MagicMock(

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -195,8 +195,8 @@ def test_IH_is_used(example_estimate_competence, create_pool_classifiers):
 
     ds_test.DSEL_processed_ = dsel_processed
 
-    ds_test._get_region_competence = MagicMock(return_value=(distances,
-                                                             neighbors))
+    ds_test.get_region_competence = MagicMock(return_value=(distances,
+                                                            neighbors))
     predicted = ds_test.predict(query)
 
     assert np.array_equal(predicted, expected)
@@ -239,8 +239,8 @@ def test_predict_proba_IH_knn(index,
     neighbors = neighbors[index, :]
     distances = distances[index, :]
 
-    ds_test._get_region_competence = MagicMock(return_value=(distances,
-                                                             neighbors))
+    ds_test.get_region_competence = MagicMock(return_value=(distances,
+                                                            neighbors))
 
     ds_test.roc_algorithm_.predict_proba = MagicMock(
         return_value=np.atleast_2d([0.45, 0.55]))
@@ -263,8 +263,8 @@ def test_predict_proba_instance_called(index,
     neighbors = neighbors[index, :]
     distances = distances[index, :]
 
-    ds_test._get_region_competence = MagicMock(return_value=(distances,
-                                                             neighbors))
+    ds_test.get_region_competence = MagicMock(return_value=(distances,
+                                                            neighbors))
 
     ds_test.predict_proba_with_ds = MagicMock(
         return_value=np.atleast_2d([0.25, 0.75]))


### PR DESCRIPTION
Refactoring the basic `get_region_competence`, `estimate_competence`, `select`, and `classify_with_ds` methods. Removing the need to pass the query through all steps. Query now is only needed for estimating the region of competence.

Also making the method to compute the region of competence, `get_region_competence` public.