### PR TITLE
Allow random subspace from Scikit-learn

### DIFF
--- a/deslib/base.py
+++ b/deslib/base.py
@@ -97,7 +97,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         # allow base models with feature subspaces.
         if hasattr(self.pool_classifiers_, "estimators_features_"):
             self.estimator_features_ = \
-                self.pool_classifiers_.estimators_features_
+                np.array(self.pool_classifiers_.estimators_features_)
         else:
             indices = np.arange(X.shape[1])
             self.estimator_features_ = np.tile(indices,

--- a/deslib/base.py
+++ b/deslib/base.py
@@ -96,7 +96,8 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         self.n_classifiers_ = len(self.pool_classifiers_)
         # allow base models with feature subspaces.
         if hasattr(self.pool_classifiers_, "estimators_features_"):
-            self.estimator_features_ = self.pool_classifiers_.estimators_features_
+            self.estimator_features_ = \
+                self.pool_classifiers_.estimators_features_
         else:
             indices = np.arange(X.shape[1])
             self.estimator_features_ = np.tile(indices,
@@ -196,7 +197,7 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         pass
 
     @abstractmethod
-    def classify_with_ds(self,predictions, probabilities=None,
+    def classify_with_ds(self, predictions, probabilities=None,
                          neighbors=None, distances=None, DFP_mask=None):
         """Predicts the label of the corresponding query sample.
         Returns the predicted label.

--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -89,7 +89,7 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
         # allow base models with feature subspaces.
         if hasattr(self.pool_classifiers_, "estimators_features_"):
             self.estimator_features_ = \
-                self.pool_classifiers_.estimators_features_
+                np.array(self.pool_classifiers_.estimators_features_)
         else:
             indices = np.arange(X.shape[1])
             self.estimator_features_ = np.tile(indices,

--- a/deslib/static/base.py
+++ b/deslib/static/base.py
@@ -86,12 +86,19 @@ class BaseStaticEnsemble(BaseEstimator, ClassifierMixin):
             self.pool_classifiers_ = self.pool_classifiers
 
         self.n_classifiers_ = len(self.pool_classifiers_)
+        # allow base models with feature subspaces.
+        if hasattr(self.pool_classifiers_, "estimators_features_"):
+            self.estimator_features_ = \
+                self.pool_classifiers_.estimators_features_
+        else:
+            indices = np.arange(X.shape[1])
+            self.estimator_features_ = np.tile(indices,
+                                               (self.n_classifiers_, 1))
 
         self._validate_pool()
         # dealing with label encoder
         self._check_label_encoder()
         self.y_enc_ = self._setup_label_encoder(y)
-
         self.n_classes_ = self.classes_.size
         self.n_features_ = X.shape[1]
 

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -142,12 +142,18 @@ class SingleBest(BaseStaticEnsemble):
 
         """
         self._check_is_fitted()
-
         if "predict_proba" not in dir(self.best_clf_):
             raise ValueError(
                 "Base classifier must support the predict_proba function.")
+        X = check_array(X)
+        if self.n_features_ != X.shape[1]:
+            raise ValueError("Number of features of the model must "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1}."
+                             "".format(self.n_features_, X.shape[1]))
 
-        predicted_proba = self.best_clf_.predict_proba(X)
+        predicted_proba = self.best_clf_.predict_proba(
+            X[:, self.estimator_features_[self.best_clf_index_]])
         return predicted_proba
 
     def _check_is_fitted(self):

--- a/deslib/static/single_best.py
+++ b/deslib/static/single_best.py
@@ -93,7 +93,8 @@ class SingleBest(BaseStaticEnsemble):
         performances = np.zeros(self.n_classifiers_)
         for idx, clf in enumerate(self.pool_classifiers_):
             scorer = check_scoring(clf, self.scoring)
-            performances[idx] = scorer(clf, X, y)
+            performances[idx] = scorer(clf,
+                                       X[:, self.estimator_features_[idx]], y)
         return performances
 
     def predict(self, X):
@@ -110,10 +111,19 @@ class SingleBest(BaseStaticEnsemble):
         predicted_labels : array of shape (n_samples)
                            Predicted class for each sample in X.
         """
-        X = check_array(X)
         self._check_is_fitted()
-        predicted_labels = self._encode_base_labels(self.best_clf_.predict(X))
-        return self.classes_.take(predicted_labels.astype(np.int))
+        X = check_array(X)
+        if self.n_features_ != X.shape[1]:
+            raise ValueError("Number of features of the model must "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1}."
+                             "".format(self.n_features_, X.shape[1]))
+
+        predictions = self.best_clf_.predict(
+            X[:, self.estimator_features_[self.best_clf_index_]])
+
+        predictions = self._encode_base_labels(predictions)
+        return self.classes_.take(predictions.astype(np.int))
 
     def predict_proba(self, X):
         """Estimates the posterior probabilities for each class for each sample

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -167,8 +167,8 @@ class StaticSelection(BaseStaticEnsemble):
                              "".format(self.n_features_, X.shape[1]))
 
         self._check_predict_proba()
-        proba = predict_proba_ensemble(self.ensemble_, X,
-                                       self.estimator_features_)
+        features = self.estimator_features_[self.clf_indices_]
+        proba = predict_proba_ensemble(self.ensemble_, X, features)
         return proba
 
     def _validate_parameters(self):

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -128,14 +128,13 @@ class StaticSelection(BaseStaticEnsemble):
         predicted_labels : array of shape (n_samples)
                            Predicted class for each sample in X.
         """
+        self._check_is_fitted()
         X = check_array(X)
         if self.n_features_ != X.shape[1]:
             raise ValueError("Number of features of the model must "
                              "match the input. Model n_features is {0} and "
                              "input n_features is {1}."
                              "".format(self.n_features_, X.shape[1]))
-
-        self._check_is_fitted()
 
         votes = np.zeros((X.shape[0], self.n_classifiers_ensemble_))
         for idx, clf in enumerate(self.ensemble_):

--- a/deslib/static/static_selection.py
+++ b/deslib/static/static_selection.py
@@ -5,11 +5,11 @@
 # License: BSD 3 clause
 
 import numpy as np
-from deslib.util.aggregation import majority_voting_rule
-from deslib.util.aggregation import predict_proba_ensemble
 from sklearn.metrics import check_scoring
 from sklearn.utils.validation import check_is_fitted, check_X_y, check_array
 
+from deslib.util.aggregation import majority_voting_rule
+from deslib.util.aggregation import predict_proba_ensemble
 from .base import BaseStaticEnsemble
 
 
@@ -104,7 +104,8 @@ class StaticSelection(BaseStaticEnsemble):
 
         for clf_idx, clf in enumerate(self.pool_classifiers_):
             scorer = check_scoring(clf, self.scoring)
-            performances[clf_idx] = scorer(clf, X, y_encoded)
+            performances[clf_idx] = scorer(clf, X[:, self.estimator_features_[
+                                                         clf_idx]], y_encoded)
 
         self.clf_indices_ = np.argsort(performances)[::-1][
                             0:self.n_classifiers_ensemble_]
@@ -128,11 +129,18 @@ class StaticSelection(BaseStaticEnsemble):
                            Predicted class for each sample in X.
         """
         X = check_array(X)
+        if self.n_features_ != X.shape[1]:
+            raise ValueError("Number of features of the model must "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1}."
+                             "".format(self.n_features_, X.shape[1]))
+
         self._check_is_fitted()
 
         votes = np.zeros((X.shape[0], self.n_classifiers_ensemble_))
-        for clf_index, clf in enumerate(self.ensemble_):
-            votes[:, clf_index] = self._encode_base_labels(clf.predict(X))
+        for idx, clf in enumerate(self.ensemble_):
+            X_space = X[:, self.estimator_features_[self.clf_indices_[idx]]]
+            votes[:, idx] = self._encode_base_labels(clf.predict(X_space))
 
         predicted_labels = majority_voting_rule(votes).astype(int)
 
@@ -152,8 +160,16 @@ class StaticSelection(BaseStaticEnsemble):
                            Probabilities estimates for each sample in X.
          """
         self._check_is_fitted()
+        X = check_array(X)
+        if self.n_features_ != X.shape[1]:
+            raise ValueError("Number of features of the model must "
+                             "match the input. Model n_features is {0} and "
+                             "input n_features is {1}."
+                             "".format(self.n_features_, X.shape[1]))
+
         self._check_predict_proba()
-        proba = predict_proba_ensemble(self.ensemble_, X)
+        proba = predict_proba_ensemble(self.ensemble_, X,
+                                       self.estimator_features_)
         return proba
 
     def _validate_parameters(self):

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -583,7 +583,7 @@ def test_single_best_subspaces_proba():
 
     single_best = SingleBest(pool)
     single_best.fit(X_dsel, y_dsel)
-    y_pred = single_best.predict_proba(X_dsel).argmax(axis=1)
+    y_pred = single_best.predict_proba(X_test).argmax(axis=1)
 
     assert np.isclose(accuracy_score(y_pred, y_test),
                       0.9627659574468085)

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -496,7 +496,7 @@ def test_oracle_subspaces_proba():
 
     oracle = Oracle(pool)
     oracle.fit(X_dsel, y_dsel)
-    y_pred = oracle.predict_proba(X_test).argmax(axis=1)
+    y_pred = oracle.predict_proba(X_test, y_test).argmax(axis=1)
     assert np.isclose(accuracy_score(y_pred, y_test),
                       0.9946808510638298)
 
@@ -583,7 +583,7 @@ def test_single_best_subspaces_proba():
 
     single_best = SingleBest(pool)
     single_best.fit(X_dsel, y_dsel)
-    y_pred = single_best.predict_proba(X_dsel, y_dsel).argmax(axis=1)
+    y_pred = single_best.predict_proba(X_dsel).argmax(axis=1)
 
     assert np.isclose(accuracy_score(y_pred, y_test),
                       0.9627659574468085)

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -425,3 +425,34 @@ def test_meta_no_pool_of_classifiers():
     meta_des = METADES(random_state=rng, DSEL_perc=0.5)
     meta_des.fit(X_train, y_train)
     assert np.isclose(meta_des.score(X_test, y_test), 0.8936170212765957)
+
+
+def test_ola_subspaces():
+    rng = np.random.RandomState(123456)
+    X_dsel, X_test, X_train, y_dsel, y_test, y_train = load_dataset(
+        None, rng)
+    # split the data into training and test data
+    pool = BaggingClassifier(LogisticRegression(),
+                             bootstrap_features=True,
+                             max_features=0.5,
+                             random_state=rng).fit(X_train, y_train)
+
+    ola = OLA(pool)
+    ola.fit(X_dsel, y_dsel)
+    assert np.isclose(ola.score(X_test, y_test),
+                      0.9680851063829787)
+
+
+def test_knorae_subspaces():
+    rng = np.random.RandomState(123456)
+    X_dsel, X_test, X_train, y_dsel, y_test, y_train = load_dataset(
+        None, rng)
+    # split the data into training and test data
+    pool = BaggingClassifier(LogisticRegression(),
+                             max_features=0.5,
+                             random_state=rng).fit(X_train, y_train)
+
+    knorae = KNORAE(pool)
+    knorae.fit(X_dsel, y_dsel)
+    assert np.isclose(knorae.score(X_test, y_test),
+                      0.9787234042553191)

--- a/deslib/util/aggregation.py
+++ b/deslib/util/aggregation.py
@@ -244,7 +244,9 @@ def predict_proba_ensemble(classifier_ensemble, X, estimator_features=None):
     predicted_proba : array of shape (n_samples, n_classes)
         Posterior probabilities estimates for each samples in X.
     """
-    ensemble_proba = _get_ensemble_probabilities(classifier_ensemble, X)
+    ensemble_proba = _get_ensemble_probabilities(classifier_ensemble,
+                                                 X,
+                                                 estimator_features)
     n_classifiers = ensemble_proba.shape[1]
     predicted_proba = np.sum(ensemble_proba, axis=1) / n_classifiers
     return predicted_proba

--- a/deslib/util/aggregation.py
+++ b/deslib/util/aggregation.py
@@ -191,7 +191,8 @@ def sum_votes_per_class(predictions, n_classes):
     return votes
 
 
-def _get_ensemble_probabilities(classifier_ensemble, X):
+def _get_ensemble_probabilities(classifier_ensemble, X,
+                                estimator_features=None):
     """Get the probabilities estimate for each base classifier in the ensemble
 
     Parameters
@@ -202,6 +203,9 @@ def _get_ensemble_probabilities(classifier_ensemble, X):
     X : array of shape (n_samples, n_features)
         The input data.
 
+    estimator_features : array of shape (n_classifiers, n_selected_features)
+        Indices containing the features used by each classifier.
+
     Returns
     -------
     list_proba : array of shape (n_samples, n_classifiers, n_classes)
@@ -209,15 +213,18 @@ def _get_ensemble_probabilities(classifier_ensemble, X):
         samples in X.
     """
     list_proba = []
-    for clf in classifier_ensemble:
-        list_proba.append(clf.predict_proba(X))
-
+    if estimator_features is None:
+        for idx, clf in enumerate(classifier_ensemble):
+            list_proba.append(clf.predict_proba(X))
+    else:
+        for idx, clf in enumerate(classifier_ensemble):
+            list_proba.append(clf.predict_proba(X[:, estimator_features[idx]]))
     # transpose the array to have the
     # shape = [n_samples, n_classifiers, n_classes]
     return np.array(list_proba).transpose((1, 0, 2))
 
 
-def predict_proba_ensemble(classifier_ensemble, X):
+def predict_proba_ensemble(classifier_ensemble, X, estimator_features=None):
     """Estimates the posterior probabilities of the give ensemble for each
     sample in X.
 
@@ -228,6 +235,9 @@ def predict_proba_ensemble(classifier_ensemble, X):
 
     X : array of shape (n_samples, n_features)
         The input data.
+
+    estimator_features : array of shape (n_classifiers, n_selected_features)
+        Indices containing the features used by each classifier.
 
     Returns
     -------


### PR DESCRIPTION
This PR adds compatibility with the random subspace ensembles from scikit-learn (as part of the BaggingClassifier). Variable estimator_features_ found on scikit-learn ensembles is used to distribute the right feature subspace for each base classifier. 
This PR closes issues #218 and #238 